### PR TITLE
[Core] Redirects HTTP requests to unmock

### DIFF
--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -1,5 +1,8 @@
 from .__version__ import __version__  # Conform to PEP-0396
 
+from .core import *
 from . import pytest
 from . import flask
 from . import django
+
+del core

--- a/unmock/core/__init__.py
+++ b/unmock/core/__init__.py
@@ -1,5 +1,4 @@
 from .options import *
-from .unmock import *
 from .utils import *
 from .http import *
 

--- a/unmock/core/__init__.py
+++ b/unmock/core/__init__.py
@@ -1,0 +1,6 @@
+from .options import *
+from .unmock import *
+from .utils import *
+from .http import *
+
+__all__ = ["initialize", "reset", "UnmockOptions"]

--- a/unmock/core/http.py
+++ b/unmock/core/http.py
@@ -1,0 +1,11 @@
+try:
+    import http.client as http_client
+except ModuleNotFoundError:
+    import httplib as http_client
+
+# Backup:
+UNMOCK_AUTH = "___u__n_m_o_c_k_a_u_t__h_"
+HTTPConnectionInit = http_client.HTTPConnection.__init__
+HTTPConnectioRequest = http_client.HTTPConnection.request
+HTTPConnectionSend = http_client.HTTPConnection.send
+

--- a/unmock/core/http.py
+++ b/unmock/core/http.py
@@ -19,72 +19,110 @@ def parse_url(url) -> SplitResult:
     return parsed_url
 
 def initialize(unmock_options: UnmockOptions, story: Optional[List[str]] = None, token: Optional[str] = None):
+    """Entry point to mock the standard http client. Both `urllib` and `requests` library use the
+    `http.client.HTTPConnection`, so mocking it should support their use aswell.
+
+    We mock the "low level" API (instead of the `request` method, we mock the `putrequest`, `putheader`, `endheaders`
+    and `getresponse` methods; the `request` method calls these sequentially).
+
+    HTTPSConnection also uses the regular HTTPConnection methods under the hood -> hurray!
+    """
     global PATCHERS, STORIES
     if story is not None:
         STORIES += story
 
     def unmock_putrequest(self: http.client.HTTPConnection, method, url, skip_host=False, skip_accept_encoding=False):
+        """putrequest mock; called initially after the HTTPConnection object has been created. Contains information
+        about the endpoint and method."""
         global STORIES
-        if unmock_options._is_host_whitelisted(self.host):
+        if unmock_options._is_host_whitelisted(self.host):  # Host is whitelisted, redirect to original call.
             original_putrequest(self, method, url, skip_host, skip_accept_encoding)
 
-        elif not hasattr(self, "unmock"):  # Store unmock related stuff here
+        elif not hasattr(self, "unmock"):
+            # Otherwise, we create our own HTTPSConnection to redirect the call to our service when needed.
+            # We add the "unmock" attribute to this object and store information for later use.
             uri = parse_url(url)
             req = http.client.HTTPSConnection(unmock_options.unmock_host, unmock_options.unmock_port)
+            """
+            By order:
+            - headers_qp -> contains header information that is used in *q*uery *p*arameters
+            - path -> stores the endpoint for the request
+            - story -> stores previous access to the unmock service
+            - headers -> actual headers to send to the unmock API
+            - method -> actual method to use with the unmock API (always matches the method for the original request)
+            """
             req.__setattr__("unmock_data", { "headers_qp": dict(),
                                              "path": "{path}?{query}".format(path=uri.path, query=uri.query),
                                              "story": STORIES,
                                              "headers": dict(),
-                                             "method": method,
-                                             "body": None })
+                                             "method": method })
             self.__setattr__("unmock", req)
 
 
     def unmock_putheader(self: http.client.HTTPConnection, header, *values):
-        decoded_values = list()
-        for v in values:
-            try:
-                v = v.decode()
-                decoded_values.append(v)
-            except AttributeError:
-                decoded_values.append(v)
+        """putheader mock; called sequentially after the putrequest.
+        Here we simply redirect the different headers as either query parameters to be used, to part of the actual
+        headers to be used to the unmock request.
+        """
 
-        if unmock_options._is_host_whitelisted(self.host):
-            original_putheader(self, header, *decoded_values)
+        if unmock_options._is_host_whitelisted(self.host):  # Host is whitelisted, redirect to original call.
+            original_putheader(self, header, *values)
 
-        elif header == "Authorization":
-            self.unmock.unmock_data["headers_qp"][header] = decoded_values
+        elif header == "Authorization":  # Authorization is part of the query parameters
+            self.unmock.unmock_data["headers_qp"][header] = values
 
-        elif header == UNMOCK_AUTH:
-            self.unmock.unmock_data["headers"]["Authorization"] = decoded_values
+        elif header == UNMOCK_AUTH:  # UNMOCK_AUTH is part of the actual headers
+            self.unmock.unmock_data["headers"]["Authorization"] = values
 
-        else:
-            self.unmock.unmock_data["headers_qp"][header] = decoded_values
-            self.unmock.unmock_data["headers"][header] = decoded_values
+        else:  # Otherwise, we both use it for query parameters and for the actual headers
+            self.unmock.unmock_data["headers_qp"][header] = values
+            self.unmock.unmock_data["headers"][header] = values
+
 
     def unmock_end_headers(self: http.client.HTTPConnection, message_body=None, *, encode_chunked=False):
-        if unmock_options._is_host_whitelisted(self.host):
+        """endheaders mock; signals the end of the HTTP request.
+        At this point we should have all the data to make the request to the unmock service.
+        """
+
+        if unmock_options._is_host_whitelisted(self.host):  # Host is whitelisted, redirect to original call.
             original_endheaders(self, message_body, encode_chunked=encode_chunked)
+
         else:
+            # Otherwise we make the actual call to the unmock service
             unmock_data = self.unmock.unmock_data
             method = unmock_data["method"]
-            query = unmock_options._build_path(story=unmock_data["story"], host=self.host, method=method,
-                                               headers=unmock_data["headers_qp"],
-                                               path="{path}".format(path=unmock_data["path"]))
+
+            # Builds the query parameters line
+            query = unmock_options._build_query(story=unmock_data["story"], host=self.host, method=method,
+                                                headers=unmock_data["headers_qp"],
+                                                path="{path}".format(path=unmock_data["path"]))
+
+            # Make the request to the service
             original_putrequest(self.unmock, method=method,
                                 url="{fake_path}?{query}".format(fake_path=unmock_options._xy(token), query=query))
+
+            # Add all the actual headers to the request
             for header, value in unmock_data["headers"].items():
                 original_putheader(self.unmock, header, *value)
+
+            # Save body and call original endheaders with the body message
             self.unmock.unmock_data["body"] = message_body
             original_endheaders(self.unmock, message_body, encode_chunked=encode_chunked)
 
+
     def unmock_get_response(self: http.client.HTTPConnection):
+        """getresponse mock; fetches the response from the connection made.
+        Here we just need to redirect and use the getresponse from the linked unmock connection, output some messages
+        and update the stories.
+        """
         global STORIES
-        if unmock_options._is_host_whitelisted(self.host):
+        if unmock_options._is_host_whitelisted(self.host):  # Host is whitelisted, redirect to original call.
             return original_getresponse(self)
+
         elif hasattr(self, "unmock"):
             unmock_data = self.unmock.unmock_data
-            res: http.client.HTTPResponse = original_getresponse(self.unmock)
+            res: http.client.HTTPResponse = original_getresponse(self.unmock)  # Get unmocked response
+            # Report the unmocked response, URL, and updates stories
             new_story = unmock_options._end_reporter(res=res, data=unmock_data["body"], host=self.host,
                                                      method=unmock_data["method"], path=unmock_data["path"],
                                                      story=STORIES, xy=unmock_options._xy(token))
@@ -92,6 +130,7 @@ def initialize(unmock_options: UnmockOptions, story: Optional[List[str]] = None,
                 STORIES.append(new_story)
             return res
 
+    # Create the patchers and mock away!
     original_putrequest = PATCHERS.patch("http.client.HTTPConnection.putrequest", unmock_putrequest)
     original_putheader = PATCHERS.patch("http.client.HTTPConnection.putheader", unmock_putheader)
     original_endheaders = PATCHERS.patch("http.client.HTTPConnection.endheaders", unmock_end_headers)
@@ -99,5 +138,6 @@ def initialize(unmock_options: UnmockOptions, story: Optional[List[str]] = None,
     PATCHERS.start()
 
 def reset():
-    global PATCHERS
+    global PATCHERS, STORIES
     PATCHERS.stop()
+    STORIES = list()  # Reset stories

--- a/unmock/core/http.py
+++ b/unmock/core/http.py
@@ -1,11 +1,101 @@
-try:
-    import http.client as http_client
-except ModuleNotFoundError:
-    import httplib as http_client
+from typing import Optional, List
+import http.client
+from urllib.parse import urlsplit, SplitResult
+import socket
+from unittest import mock
+
+from .options import UnmockOptions
+from .utils import end_reporter
 
 # Backup:
 UNMOCK_AUTH = "___u__n_m_o_c_k_a_u_t__h_"
-HTTPConnectionInit = http_client.HTTPConnection.__init__
-HTTPConnectioRequest = http_client.HTTPConnection.request
-HTTPConnectionSend = http_client.HTTPConnection.send
 
+def parse_url(url) -> SplitResult:
+    parsed_url = urlsplit(url)
+    if parsed_url.scheme == "" or parsed_url.netloc == "":
+        return urlsplit("http://{url}".format(url=url))
+    return parsed_url
+
+def initialize(unmock_options: UnmockOptions, story: Optional[List[str]] = None, token: Optional[str] = None):
+    story = story or list()
+
+    def unmock_putrequest(self: http.client.HTTPConnection, method, url, skip_host=False, skip_accept_encoding=False):
+        if unmock_options.is_host_whitelisted(self.host):
+            original_putrequest(self, method, url, skip_host, skip_accept_encoding)
+
+        elif not hasattr(self, "unmock"):  # Store unmock related stuff here
+            uri = parse_url(url)
+            req = http.client.HTTPSConnection(unmock_options.unmock_host, unmock_options.unmock_port)
+            req.__setattr__("unmock_headers", { "headers": dict(),
+                                                "path": "{path}?{query}".format(path=uri.path, query=uri.query),
+                                                "story": story,
+                                                "method": method })
+            self.__setattr__("unmock", req)
+
+
+    def unmock_putheader(self: http.client.HTTPConnection, header, *values):
+        decoded_values = list()
+        for v in values:
+            try:
+                v = v.decode()
+                decoded_values.append(v)
+            except AttributeError:
+                decoded_values.append(v)
+
+        if unmock_options.is_host_whitelisted(self.host):
+            original_putheader(self, header, *decoded_values)
+
+        elif header == "Authorization":
+            self.unmock.unmock_headers["headers"][header] = decoded_values
+
+        elif header == UNMOCK_AUTH:
+            self.unmock.unmock_headers["Authorization"] = "".join(decoded_values)
+            # original_putheader(self.unmock, "Authorization", *decoded_values)
+
+        else:
+            self.unmock.unmock_headers["headers"][header] = decoded_values
+            # original_putheader(self.unmock, header, *decoded_values)
+
+    def unmock_end_headers(self: http.client.HTTPConnection, message_body=None, *, encode_chunked=False):
+        print("End Headers:", message_body, encode_chunked, self.unmock.unmock_headers)
+
+        if unmock_options.is_host_whitelisted(self.host):
+            print(self.host, "in whitelisted mocked endheaders")
+            original_endheaders(self, message_body, encode_chunked=encode_chunked)
+        else:
+            print(self.host, "in mocked endheaders")
+            # Build body (query parameters)
+            # if message_body is not None:
+            #     original_putheader(self.unmock, "body", message_body)
+            query = unmock_options.build_path(story=story, host=self.host, method=self.unmock.unmock_headers["method"],
+                                              headers=self.unmock.unmock_headers["headers"],
+                                              path="{path}".format(path=self.unmock.unmock_headers["path"]))
+            original_putrequest(self.unmock, method="GET",
+                                url="{fake_path}?{query}".format(fake_path=unmock_options.xy(token), query=query))
+            print("\n")
+            print("{fake_path}?{query}".format(fake_path=unmock_options.xy(token), query=query))
+            print(message_body)
+            print("\n")
+            for k, v in self.unmock.__dict__.items():
+                print(k, ":", v)
+            # original_putheader(self.unmock, "Authorization", self.unmock.unmock_headers.get("Authorization", "").encode())
+            # TODO: call to end_reporter for a nice printout
+            # print(body)
+            original_endheaders(self.unmock, message_body, encode_chunked=encode_chunked)
+
+    putrequest_patcher = mock.patch("http.client.HTTPConnection.putrequest", unmock_putrequest)
+    putheader_patcher = mock.patch("http.client.HTTPConnection.putheader", unmock_putheader)
+    endheaders_patcher = mock.patch("http.client.HTTPConnection.endheaders", unmock_end_headers)
+
+    original_putrequest = putrequest_patcher.get_original()[0]
+    original_putheader = putheader_patcher.get_original()[0]
+    original_endheaders = endheaders_patcher.get_original()[0]
+
+    putheader_patcher.start()
+    endheaders_patcher.start()
+    putrequest_patcher.start()
+
+def reset():
+    pass
+    # http.client.HTTPConnection.putrequest = HTTPConnectionPutRequest
+    # http.client.HTTPSConnection.putrequest = HTTPConnectionPutRequest

--- a/unmock/core/options.py
+++ b/unmock/core/options.py
@@ -1,0 +1,61 @@
+from typing import Union, List, Optional
+
+class UnmockOptions:
+    def __init__(self, save: Union[bool, List[str]] = False, unmock_host: str = "api.unmock.io", unmock_port = 443,
+                 use_in_production: bool = False,
+                 logger=None, persistence=None,  # TODO
+                 ignore=None, signature: Optional[str] = None, token: Optional[str] = None,
+                 whitelist: Optional[List[Str]] = None):
+        self.logger = logger
+        self.persistence = persistence
+        self.save = save
+        self.unmock_host = unmock_host
+        self.unmock_port = unmock_port
+        self.use_in_production = use_in_production
+        self.ignore = ignore if ignore is not None else {headers: r"\w*User-Agent\w*"}
+        self.signature = signature
+        self.token = token
+        self.whitelist = whitelist if whitelist is not None else ["127.0.0.1", "127.0.0.0", "localhost"]
+
+"""
+export const defaultOptions: IUnmockInternalOptions = {
+  ignore: {headers: "\w*User-Agent\w*"},
+  logger: isNode ?
+    new (__non_webpack_require__("./logger/winston-logger").default)() :
+    new (require("./logger/browser-logger").default)(),
+  persistence: isNode ?
+    new (__non_webpack_require__("./persistence/fs-persistence").default)() :
+    new (require("./persistence/local-storage-persistence").default)(),
+  save: false,
+  unmockHost: "api.unmock.io",
+  unmockPort: "443",
+  useInProduction: false,
+  whitelist: ["127.0.0.1", "127.0.0.0", "localhost"],
+};
+
+export interface IUnmockInternalOptions {
+    logger: ILogger;
+    persistence: IPersistence;
+    save: boolean | string[];
+    unmockHost: string;
+    unmockPort: string;
+    useInProduction: boolean;
+    ignore?: any;
+    signature?: string;
+    token?: string;
+    whitelist?: string[];
+}
+
+export interface IUnmockOptions {
+    logger?: ILogger;
+    persistence?: IPersistence;
+    save?: boolean | string[];
+    unmockHost?: string;
+    unmockPort?: string;
+    ignore?: any;
+    signature?: string;
+    token?: string;
+    whitelist?: string[];
+    useInProduction?: boolean;
+}
+"""

--- a/unmock/core/options.py
+++ b/unmock/core/options.py
@@ -4,6 +4,8 @@ from http.client import HTTPResponse
 import logging
 import json
 
+__all__ = ["UnmockOptions"]
+
 UNMOCK_HOST = "api.unmock.io"
 UNMOCK_PORT = 443
 
@@ -34,15 +36,15 @@ class UnmockOptions:
         # Add the unmock host to whitelist:
         self.whitelist.append(unmock_host)
 
-    def is_host_whitelisted(self, host: str):
+    def _is_host_whitelisted(self, host: str):
         return host in self.whitelist
 
     @staticmethod
-    def xy(xy):
+    def _xy(xy):
         return "/x/" if xy else "/y/"
 
-    def build_path(self, story: Optional[List[str]],  headers: Dict[str, Any], host: Optional[str] = None,
-                   method: Optional[str] = None, path: Optional[str] = None):
+    def _build_query(self, story: Optional[List[str]],  headers: Dict[str, Any], host: Optional[str] = None,
+                     method: Optional[str] = None, path: Optional[str] = None):
         qs = {
             "story": json.dumps(story),
             "path": path or "",
@@ -56,7 +58,7 @@ class UnmockOptions:
             qs["signature"] = self.signature
         return urlencode(qs)
 
-    def end_reporter(self, res: HTTPResponse, data: Any, host: str, method: str, path: str, story: List[str], xy: str):
+    def _end_reporter(self, res: HTTPResponse, data: Any, host: str, method: str, path: str, story: List[str], xy: str):
         headers = res.headers
         unmock_hash = headers["unmock-hash"]
         if unmock_hash not in story:

--- a/unmock/core/options.py
+++ b/unmock/core/options.py
@@ -1,7 +1,8 @@
 from typing import Union, List, Optional, Dict, Any
 from urllib.parse import urlencode
-
-from .utils import json_stringify
+from http.client import HTTPResponse
+import logging
+import json
 
 UNMOCK_HOST = "api.unmock.io"
 UNMOCK_PORT = 443
@@ -12,13 +13,21 @@ class UnmockOptions:
                  logger=None, persistence=None,
                  ignore=None, signature: Optional[str] = None, token: Optional[str] = None,
                  whitelist: Optional[List[str]] = None):
-        self.logger = logger  # TODO
+        if logger is None:
+            # TODO - move the logging definition elsewhere? Console output by default?
+            logger = logging.getLogger("reporter")
+            frmtr = logging.Formatter("[%(asctime)s] %(levelname)s\\%(name)s - %(message)s")
+            console_handler = logging.StreamHandler()
+            console_handler.setFormatter(frmtr)
+            logger.setLevel(logging.INFO)
+            logger.addHandler(console_handler)
+        self.logger = logger
         self.persistence = persistence  # TODO
         self.save = save
         self.unmock_host = unmock_host
         self.unmock_port = unmock_port
         self.use_in_production = use_in_production
-        self.ignore = ignore if ignore is not None else { "headers": "\w*User-Agent\w*" }
+        self.ignore = ignore if ignore is not None else { "headers": r"\w*User-Agent\w*" }
         self.signature = signature
         self.token = token
         self.whitelist = whitelist if whitelist is not None else ["127.0.0.1", "127.0.0.0", "localhost"]
@@ -35,14 +44,31 @@ class UnmockOptions:
     def build_path(self, story: Optional[List[str]],  headers: Dict[str, Any], host: Optional[str] = None,
                    method: Optional[str] = None, path: Optional[str] = None):
         qs = {
-            "story": json_stringify(story),
+            "story": json.dumps(story),
             "path": path or "",
             "hostname": host or "",
             "method": method or "",
-            "headers": json_stringify(headers)
+            "headers": json.dumps(headers)
         }
         if self.ignore is not None:
-            qs["ignore"] = json_stringify(self.ignore)
+            qs["ignore"] = json.dumps(self.ignore)
         if self.signature is not None:
             qs["signature"] = self.signature
         return urlencode(qs)
+
+    def end_reporter(self, res: HTTPResponse, data: Any, host: str, method: str, path: str, story: List[str], xy: str):
+        headers = res.headers
+        unmock_hash = headers["unmock-hash"]
+        if unmock_hash not in story:
+            body = res.msg
+            self.logger.info("*****url-called*****")
+            data_string = " with data {data}".format(data=data) if data is not None else "."
+            self.logger.info("Hi! We see you've called %s %s%s%s", method, host, path, data_string)
+            self.logger.info("We've sent you mock data back. You can edit your mock at https://unmock.io%s%s.", xy,
+                             unmock_hash)
+            if (self.save == True) or (isinstance(self.save, list) and unmock_hash in self.save):
+                # self.persistence.save_headers(hash, headers)  # TODO
+                if body is not None:
+                    # self.persistence.save_body(hash, body)  # TODO
+                    pass
+            return unmock_hash

--- a/unmock/core/utils.py
+++ b/unmock/core/utils.py
@@ -1,36 +1,9 @@
-from typing import List, Dict, Any, Union, Iterable
-import logging
+from typing import List, Dict, Any, Union
+from collections.abc import Iterable
 import json
 from unittest import mock
 
-def json_stringify(obj: Union[List, Dict[Any, Any], Any]):
-    if isinstance(obj, Iterable):
-        return ''.join(json.dumps(obj if obj is not None and len(obj) > 0 else ""))
-    return json.dumps(obj)
-
-def end_reporter(body: Any, data: str, headers: Dict[str, str], host: str, logger: logging.Logger, method: str,
-                 path: str, persistence, save: Union[bool, List[str]], selfcall: bool, story: List[str], xy: str):
-    if logger is None:  # Simple printouts by default?
-        # TODO - move the logging definition elsewhere
-        logger = logging.getLogger("reporter")
-        frmtr = logging.Formatter("[%(asctime)s] %(levelname)s\\%(name)s - %(message)s")
-        console_handler = logging.StreamHandler()
-        console_handler.setFormatter(frmtr)
-        logger.setLevel(logging.INFO)
-        logger.addHandler(console_handler)
-    if not selfcall:
-        unmock_hash = headers["unmock-hash"]
-        if unmock_hash not in story:
-            logger.info("*****url-called*****")
-            data_string = " with data {data}".format(data=data) if data is not None else "."
-            logger.info("Hi! We see you've called %s %s%s%s", method, host, path, data_string)
-            logger.info("We've sent you mock data back. You can edit your mock at https://unmock.io/%s%s.", xy, unmock_hash)
-            if (isinstance(save, bool) and save == True) or (isinstance(save, list) and unmock_hash in save):
-                # persistence.save_headers(hash, headers)  # TODO
-                if body is not None:
-                    # persistence.save_body(hash, body)  # TODO
-                    pass
-            return unmock_hash
+__all__ = ["Patchers"]
 
 class Patchers:
     """Represents a collection of mock.patcher objects to be started/stopped simulatenously."""

--- a/unmock/core/utils.py
+++ b/unmock/core/utils.py
@@ -1,0 +1,29 @@
+from typing import Optional, List, Dict, Any, Union
+from collections.abs import Iterable
+import json
+
+from urllib.parse import urlencode
+
+def json_stringify(obj: Union[List, Dict[Any, Any], Any]):
+    if isinstance(obj, Iterable):
+        return ''.join(json.dumps(obj if obj is not None and len(obj) > 0 else []))
+    return json.dumps(obj)
+
+def build_path(unmock_host: str, xy: bool, story: Optional[List[str]], ignore: Optional[Dict[str, any]],
+               headers: Dict[str, Any], host: Optional[str] = None, hostname: Optional[str] = None,
+               method: Optional[str] = None, path: Optional[str] = None, signature: Optional[str] = None):
+    if hostname == unmock_host or host == unmock_host:
+        return path
+    unmock_path = "/{xy}/".format(xy="x" if xy else "y")
+    qs = {
+        "story": json_stringify(story),
+        "path": path or "",
+        "hostname": hostname or host or "",
+        "method": method or "",
+        "headers": json_stringify(headers)
+    }
+    if ignore is not None:
+        qs["ignore"] = json_stringify(ignore)
+    if signature is not None:
+        qs["signature"] = signature
+    return "{base}{querystring}".format(base=unmock_path, querystring=urlencode(qs))

--- a/unmock/core/utils.py
+++ b/unmock/core/utils.py
@@ -1,5 +1,4 @@
-from typing import List, Dict, Any, Union
-from collections.abc import Iterable
+from typing import List, Dict, Any, Union, Iterable
 import json
 from unittest import mock
 
@@ -13,7 +12,6 @@ def end_reporter(body, data, headers, host, hostname, logger, method, path, pers
         hash = headers["unmock-hash"]
         if hash not in story:
             story.insert(0, hash)
-            # TODO:
             # logger.log("*****url-called*****")
             # logger.log("Hi! We see you've called ${method} ${hostname || host}${path}${data ? ` with data ${data}.` : `.`}")
             # logger.log("We've sent you mock data back. You can edit your mock at https://unmock.io/${xy ? "x" : "y"}/${hash}.")
@@ -24,3 +22,34 @@ def end_reporter(body, data, headers, host, hostname, logger, method, path, pers
                     # TODO
                     # persistence.save_body(hash, body)
                     pass
+
+class Patchers:
+    """Represents a collection of mock.patcher objects to be started/stopped simulatenously."""
+    def __init__(self):
+        self.patchers = list()
+
+    def patch(self, target, new_destination):
+        """Patches `target` with new_destination, and returns the original target for later use"""
+        patcher = mock.patch(target, new_destination)
+        self.register(patcher)
+        return patcher.get_original()[0]
+
+    def register(self, *patchers):
+        """Adds a list of patcher objects to this instance"""
+        self.patchers += patchers
+
+    def clear(self):
+        """Stop any ongoing patches and clears the list of patchers in this instance"""
+        if self.patchers:
+            self.stop()
+        self.patchers = list()
+
+    def start(self):
+        """Starts all registered patchers"""
+        for patcher in self.patchers:
+            patcher.start()
+
+    def stop(self):
+        """Stops all registered patchers"""
+        for patcher in self.patchers:
+            patcher.stop()

--- a/unmock/core/utils.py
+++ b/unmock/core/utils.py
@@ -1,29 +1,25 @@
-from typing import Optional, List, Dict, Any, Union
-from collections.abs import Iterable
+from typing import List, Dict, Any, Union
+from collections.abc import Iterable
 import json
-
-from urllib.parse import urlencode
 
 def json_stringify(obj: Union[List, Dict[Any, Any], Any]):
     if isinstance(obj, Iterable):
-        return ''.join(json.dumps(obj if obj is not None and len(obj) > 0 else []))
+        return ''.join(json.dumps(obj if obj is not None and len(obj) > 0 else ""))
     return json.dumps(obj)
 
-def build_path(unmock_host: str, xy: bool, story: Optional[List[str]], ignore: Optional[Dict[str, any]],
-               headers: Dict[str, Any], host: Optional[str] = None, hostname: Optional[str] = None,
-               method: Optional[str] = None, path: Optional[str] = None, signature: Optional[str] = None):
-    if hostname == unmock_host or host == unmock_host:
-        return path
-    unmock_path = "/{xy}/".format(xy="x" if xy else "y")
-    qs = {
-        "story": json_stringify(story),
-        "path": path or "",
-        "hostname": hostname or host or "",
-        "method": method or "",
-        "headers": json_stringify(headers)
-    }
-    if ignore is not None:
-        qs["ignore"] = json_stringify(ignore)
-    if signature is not None:
-        qs["signature"] = signature
-    return "{base}{querystring}".format(base=unmock_path, querystring=urlencode(qs))
+def end_reporter(body, data, headers, host, hostname, logger, method, path, persistence, save, selfcall, story, xy):
+    if not selfcall:
+        hash = headers["unmock-hash"]
+        if hash not in story:
+            story.insert(0, hash)
+            # TODO:
+            # logger.log("*****url-called*****")
+            # logger.log("Hi! We see you've called ${method} ${hostname || host}${path}${data ? ` with data ${data}.` : `.`}")
+            # logger.log("We've sent you mock data back. You can edit your mock at https://unmock.io/${xy ? "x" : "y"}/${hash}.")
+            if (isinstance(save, bool) and save == True) or (isinstance(save, list) and hash in save):
+                # TODO:
+                # persistence.save_headers(hash, headers)
+                if body is not None:
+                    # TODO
+                    # persistence.save_body(hash, body)
+                    pass

--- a/unmock/core/utils.py
+++ b/unmock/core/utils.py
@@ -1,6 +1,7 @@
 from typing import List, Dict, Any, Union
 from collections.abc import Iterable
 import json
+from unittest import mock
 
 def json_stringify(obj: Union[List, Dict[Any, Any], Any]):
     if isinstance(obj, Iterable):


### PR DESCRIPTION
Adds the basic core capabilities for unmock client.
- Mocks the `putrequest`, `putheader`, `endheaders` and `getresponse` methods for `http.client.HTTPConnection`
  - Both `urllib[2/3]` and `requests` use `http.client`, so this makes us good to go for starters; in the future we could look into e.g. `aio`, `pycurl`, etc.
  - Also `HTTPSConnection` uses the above methods, so we have that covered.
- Adds `initialize` and `reset` methods similar to the `unmock-js` client
- Adds some more structure and Pythonic styling

**Issues to be opened for future PRs**:
- [x] Tests to be added when the remaining core functions (persistence, etc) are implemented
- [x] CI (azure?)
- [x] Typing tests (mypy? pylint?)
- [x] Python 2.7 support