### PR TITLE
[Core] Restructure package for future expansion

### DIFF
--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -1,8 +1,37 @@
 from .__version__ import __version__  # Conform to PEP-0396
 
-from .core import *
 from . import pytest
 from . import flask
 from . import django
+from .core import UnmockOptions
+
+def initialize(unmock_options: UnmockOptions = None, story=None, refresh_token=None):
+    """
+    Initialize the unmock library for capturing API calls.
+
+    :param unmock_options: An Optional object allowing customization of how unmock works.
+    :type unmock_options UnmockOptions
+    :param story: An optional list of unmock stories to initialize the state. These represent previous calls to unmock
+        and make unmock stateful.
+    :type story List[str]
+    :param refresh_token: An optional unmock token identifying your account.
+    :type refresh_token str
+    """
+    from . import core  # Imported internally to keep the namespace clear
+
+    if story is not None:
+        core.STORIES += story
+    if unmock_options is None:  # Default then!
+        unmock_options = UnmockOptions(token=refresh_token)
+
+    core.http.initialize(unmock_options)
+
+
+def reset():
+    """
+    Removes Unmock automatic API call capturing, restoring normal behaviour.
+    """
+    from . import core
+    core.http.reset()
 
 del core

--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -3,7 +3,11 @@ from .__version__ import __version__  # Conform to PEP-0396
 from . import pytest
 from . import flask
 from . import django
-from .core import UnmockOptions
+from .core import UnmockOptions, exceptions
+
+def init(unmock_options: UnmockOptions = None, story=None, refresh_token=None):
+    """Shorthand for initialize"""
+    initialize(unmock_options, story, refresh_token)
 
 def initialize(unmock_options: UnmockOptions = None, story=None, refresh_token=None):
     """

--- a/unmock/core/__init__.py
+++ b/unmock/core/__init__.py
@@ -1,6 +1,11 @@
+from .utils import *  # Imported first as it defines the Patchers object
+
+# package-wide variables to be used by different capturers of API calls (whether it is http, flask, django, whatever)
+PATCHERS = Patchers()
+STORIES = list()
+
 from .persistence import *
 from .options import *
-from .utils import *
 from .http import *
 
-__all__ = ["initialize", "reset", "UnmockOptions"]
+__all__ = ["UnmockOptions"]

--- a/unmock/core/http.py
+++ b/unmock/core/http.py
@@ -27,7 +27,6 @@ def initialize(unmock_options: UnmockOptions):
     def unmock_putrequest(self: http.client.HTTPConnection, method, url, skip_host=False, skip_accept_encoding=False):
         """putrequest mock; called initially after the HTTPConnection object has been created. Contains information
         about the endpoint and method."""
-        global STORIES
         if unmock_options._is_host_whitelisted(self.host):  # Host is whitelisted, redirect to original call.
             original_putrequest(self, method, url, skip_host, skip_accept_encoding)
 
@@ -112,7 +111,6 @@ def initialize(unmock_options: UnmockOptions):
         Here we just need to redirect and use the getresponse from the linked unmock connection, output some messages
         and update the stories.
         """
-        global STORIES
         if unmock_options._is_host_whitelisted(self.host):  # Host is whitelisted, redirect to original call.
             return original_getresponse(self)
 

--- a/unmock/core/http.py
+++ b/unmock/core/http.py
@@ -2,6 +2,7 @@ from typing import Optional, List
 import http.client
 from urllib.parse import urlsplit, SplitResult
 
+from . import PATCHERS, STORIES
 from .options import UnmockOptions
 from .utils import Patchers
 
@@ -9,8 +10,6 @@ __all__ = ["initialize", "reset"]
 
 # Backup:
 UNMOCK_AUTH = "___u__n_m_o_c_k_a_u_t__h_"
-PATCHERS = Patchers()
-STORIES = list()
 
 def parse_url(url) -> SplitResult:
     parsed_url = urlsplit(url)
@@ -19,35 +18,18 @@ def parse_url(url) -> SplitResult:
         return urlsplit("https://{url}".format(url=url))
     return parsed_url
 
-def initialize(unmock_options: Optional[UnmockOptions] = None, story: Optional[List[str]] = None,
-               token: Optional[str] = None):
-    """
-    Initialize the unmock library for capturing API calls.
-
-    :param unmock_options: An Optional object allowing customization of how unmock works.
-    :type unmock_options UnmockOptions
-    :param story: An optional list of unmock stories to initialize the state. These represent previous calls to unmock
-        and make unmock stateful.
-    :type story List[str]
-    :param token: An optional unmock token identifying your account.
-    :type token str
-    """
-
-    # TODO - `token` is also used in UnmockOptions...?
+def initialize(unmock_options: UnmockOptions):
     """
     Entry point to mock the standard http client. Both `urllib` and `requests` library use the
     `http.client.HTTPConnection`, so mocking it should support their use aswell.
 
     We mock the "low level" API (instead of the `request` method, we mock the `putrequest`, `putheader`, `endheaders`
     and `getresponse` methods; the `request` method calls these sequentially).
+    To save the body of the response, we also mock the HTTPResponse's `read` method.
 
     HTTPSConnection also uses the regular HTTPConnection methods under the hood -> hurray!
     """
-    global PATCHERS, STORIES
-    if story is not None:
-        STORIES += story
-    if unmock_options is None:  # Default then!
-        unmock_options = UnmockOptions()
+    token = unmock_options.get_token()  # Get the *access_token*
 
     def unmock_putrequest(self: http.client.HTTPConnection, method, url, skip_host=False, skip_accept_encoding=False):
         """putrequest mock; called initially after the HTTPConnection object has been created. Contains information
@@ -170,6 +152,5 @@ def initialize(unmock_options: Optional[UnmockOptions] = None, story: Optional[L
     PATCHERS.start()
 
 def reset():
-    global PATCHERS, STORIES
-    PATCHERS.stop()
-    STORIES = list()  # Reset stories
+    PATCHERS.clear()
+    STORIES.clear()

--- a/unmock/core/options.py
+++ b/unmock/core/options.py
@@ -1,4 +1,4 @@
-from typing import Union, List, Optional, Dict, Any
+from typing import Union, List, Optional, Dict, Any, cast
 from urllib.parse import urlencode
 from http.client import HTTPResponse
 from http import HTTPStatus
@@ -24,11 +24,18 @@ class UnmockOptions:
         if logger is None:
             # TODO - move the logging definition elsewhere? Console output by default?
             logger = logging.getLogger("reporter")
-            frmtr = logging.Formatter("[%(asctime)s] %(levelname)s\\%(name)s - %(message)s")
-            console_handler = logging.StreamHandler()
-            console_handler.setFormatter(frmtr)
             logger.setLevel(logging.INFO)
-            logger.addHandler(console_handler)
+            # For now, make sure we only have one stream logger...
+            has_stream_handler = False
+            for handler in logger.handlers:
+                if isinstance(handler, logging.StreamHandler):
+                    has_stream_handler = True
+                    break
+            if not has_stream_handler:
+                frmtr = logging.Formatter("[%(asctime)s] %(levelname)s\\%(name)s - %(message)s")
+                console_handler = logging.StreamHandler()
+                console_handler.setFormatter(frmtr)
+                logger.addHandler(console_handler)
         self.logger = logger
         self.save = save
 


### PR DESCRIPTION
It didn't make sense to have the `initialize` and `reset` propagate up to the package level; they are specific for mocking the `/http.client.HTTP(Connection|Response)/g` classes.
This restructure makes the `http` module more specific, introduces the relevant `initialize` (and `init`, because I got tired from typing `initialize` all the time :stuck_out_tongue: ) at the package level, and moves some of the globals to a higher level.
The idea is to make it easy to extend for other libraries (mostly thinking of [aiohttp](https://aiohttp.readthedocs.io/en/stable/) and [pycurl](http://pycurl.io/)), while keeping the namespace clean.
Future extensions to mocking/capturing these libraries could now only rely on the `UnmockOptions` object (as is the case in `http`), instead of possible, specific instances of `story` and `refresh_token`.