### PR TITLE
[Fix] CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
     - run: pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock-python --cov-report=xml --cov-report=html --cov-fail-under=80
 
   deploy:
+    - image: circleci/python:3.6.8
     steps:
     - checkout
     - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ commands:
     steps:
       - run:
           name: pytest
-          command: python3 -m pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock --cov-report=xml --cov-report=html
+          command: python3 -m pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock --cov-report=xml --cov-report=html #--cov-fail-under=80
       - when:
           condition: << parameters.publish >>
           steps:
@@ -35,6 +35,14 @@ jobs:
     - setup
     - test:
         publish: true
+
+  linux27:  # Python 2.7.16
+    docker:
+      - image: circleci/python:2.7.16
+    steps:
+    - setup
+    - test
+
   linux37:  # Python 3.7.5 RC version
     docker:
       - image: circleci/python:3.7-rc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,46 @@
-version: 2
+version: 2.1
+
+commands:
+  setup:
+    description: "Installs python packages and source module"
+    steps:
+      - checkout
+      - run:
+          name: Setup Tools
+          command: python -m pip install --upgrade pip setuptools wheel
+      - run:
+          name: Installing package
+          command: pip install --upgrade -e .[dev] --user
+  test:
+    description: "Run tests, possibly publishing results"
+    parameters:
+      publish:
+        type: boolean
+        default: false
+    steps:
+      - run:
+          name: pytest
+          command: python -m pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock --cov-report=xml --cov-report=html
+      - when:
+          condition: << parameters.publish >>
+          steps:
+            - store_test_results:
+                path: junit
+
 jobs:
   build:  # default entry point for CircleCI
     docker:
       - image: circleci/python:3.6.8
     steps:
-    - checkout
-    - run: python -m pip install --upgrade pip setuptools wheel
-    - run: pip install --upgrade -e .[dev] --user
-    - run: python -m pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock --cov-report=xml --cov-report=html
-    - store_test_results:
-        path: junit/
+    - setup
+    - test:
+        publish: true
 
   deploy:
     docker:
       - image: circleci/python:3.6.8
     steps:
-    - checkout
-    - build
+    - setup
     - run: git config credential.helper "/bin/bash ./.circleci/git-credentials-helper.sh"
     - run: python setup.py upload
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ commands:
       - checkout
       - run:
           name: Setup Tools
-          command: python3 -m pip install --upgrade pip setuptools wheel
+          command: python3 -m pip install --user --upgrade pip setuptools wheel
       - run:
           name: Installing package
-          command: pip3 install --upgrade -e .[dev] --user
+          command: python3 -m pip install --user --upgrade -e .[dev]
   test:
     description: "Run tests, possibly publishing results"
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,27 @@ jobs:
     - setup
     - test:
         publish: true
+  linux37:  # Python 3.7.5 RC version
+    docker:
+      - image: circleci/python:3.7-rc
+    steps:
+    - setup
+    - test
   
   macOS36:
     macos:
       # https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-430/index.html
       # Python 3.6.5, Darwin 17.4.0, macOS 10.13.3
       xcode: "9.4.1"
+    steps:
+    - setup
+    - test
+
+  macOS37:
+    macos:
+      # https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-520/index.html
+      # Python 3.7.2, Darwin 18.2.0, macOS 10.14.3
+      xcode: "10.2.0"
     steps:
     - setup
     - test
@@ -59,9 +74,15 @@ workflows:
   build-and-deploy:
     jobs:
       - build
+      - macOS36
+      - macOS37
+      - linux37
       - deploy:
           requires:
             - build
+            - macOS36
+            - macOS37
+            - linux37
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - checkout
     - build
-    - run: git config credential.helper "/bin/bash ./git-credentials-helper.sh"
+    - run: git config credential.helper "/bin/bash ./.circleci/git-credentials-helper.sh"
     - run: python setup.py upload
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     - checkout
     - run: python -m pip install --upgrade pip setuptools wheel
     - run: pip install --upgrade -e .[dev] --user
-    - run: python -m pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock-python --cov-report=xml --cov-report=html --cov-fail-under=80
+    - run: python -m pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock --cov-report=xml --cov-report=html
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ jobs:
     - run: python -m pip install --upgrade pip setuptools wheel
     - run: pip install --upgrade -e .[dev] --user
     - run: python -m pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock --cov-report=xml --cov-report=html
+    - store_test_results:
+        path: junit/
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - checkout
     - run: python -m pip install --upgrade pip setuptools wheel
-    - run: pip install --upgrade -e .[dev]
+    - run: pip install --upgrade -e .[dev] --user
     - run: pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock-python --cov-report=xml --cov-report=html --cov-fail-under=80
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,14 +74,14 @@ workflows:
   build-and-deploy:
     jobs:
       - build
-      - macOS36
-      - macOS37
+      #- macOS36  # Commented out as we don't have that in CircleCI yet
+      #- macOS37
       - linux37
       - deploy:
           requires:
             - build
-            - macOS36
-            - macOS37
+            #- macOS36
+            #- macOS37
             - linux37
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ jobs:
     - run: pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock-python --cov-report=xml --cov-report=html --cov-fail-under=80
 
   deploy:
-    - image: circleci/python:3.6.8
+    docker:
+      - image: circleci/python:3.6.8
     steps:
     - checkout
     - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ commands:
       - checkout
       - run:
           name: Setup Tools
-          command: python -m pip install --upgrade pip setuptools wheel
+          command: python3 -m pip install --upgrade pip setuptools wheel
       - run:
           name: Installing package
-          command: pip install --upgrade -e .[dev] --user
+          command: pip3 install --upgrade -e .[dev] --user
   test:
     description: "Run tests, possibly publishing results"
     parameters:
@@ -20,7 +20,7 @@ commands:
     steps:
       - run:
           name: pytest
-          command: python -m pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock --cov-report=xml --cov-report=html
+          command: python3 -m pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock --cov-report=xml --cov-report=html
       - when:
           condition: << parameters.publish >>
           steps:
@@ -28,13 +28,23 @@ commands:
                 path: junit
 
 jobs:
-  build:  # default entry point for CircleCI
+  build:  # default entry point for CircleCI, test against Python 3.6.8
     docker:
       - image: circleci/python:3.6.8
     steps:
     - setup
     - test:
         publish: true
+  
+  macOS36:
+    macos:
+      # https://circle-macos-docs.s3.amazonaws.com/image-manifest/build-430/index.html
+      # Python 3.6.5, Darwin 17.4.0, macOS 10.13.3
+      xcode: "9.4.1"
+    steps:
+    - setup
+    - test
+
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     - checkout
     - run: python -m pip install --upgrade pip setuptools wheel
     - run: pip install --upgrade -e .[dev] --user
-    - run: pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock-python --cov-report=xml --cov-report=html --cov-fail-under=80
+    - run: python -m pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock-python --cov-report=xml --cov-report=html --cov-fail-under=80
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ workflows:
     jobs:
       - build
       - deploy:
-        requires:
-          - build
-        filters:
-          branches:
-            only: master
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/.circleci/git-credentials-helper.sh
+++ b/.circleci/git-credentials-helper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo username=$GIT_USERNAME
+echo password=$GIT_TOKEN

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ SRC_DIR = 'unmock'  # Relative location wrt setup.py
 # Required packages.
 REQUIRED = ["requests"]
 
-DEV = ["twine", "wheel", "pytest"]
+DEV = ["twine", "wheel", "pytest", "pytest-cov"]
 
 # Optional packages
 EXTRAS = {'dev': DEV}


### PR DESCRIPTION
Woohoo!
- Tests on Python 3.6.8 and Python 3.7 RC
- Jobs for macOS also ready, if we opt to go that way
- Job for Python 2.7.16 also ready, once we add support for it
- Credentials for publishing to PyPi also set, publishing when merging to master branch

Full list of CircleCI docker images and their tags can be found [here](https://circleci.com/docs/2.0/docker-image-tags.json).