### PR TITLE
[Core] Add support for Python 2.7 & Python 3.4, 3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,9 +107,6 @@ workflows:
       - linux27:
           requires:
             - build
-      - linux33:
-          requires:
-            - build
       - linux34:
           requires:
             - build
@@ -128,7 +125,6 @@ workflows:
             #- macOS36
             #- macOS37
             - linux27
-            - linux33
             - linux34
             - linux35
             - linux36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ commands:
       - checkout
       - run:
           name: Setup Tools
-          command: python3 -m pip install --user --upgrade pip setuptools wheel
+          command: python -m pip install --user --upgrade pip setuptools wheel
       - run:
           name: Installing package
-          command: python3 -m pip install --user --upgrade -e .[dev]
+          command: python -m pip install --user --upgrade -e .[dev]
   test:
     description: "Run tests, possibly publishing results"
     parameters:
@@ -20,7 +20,7 @@ commands:
     steps:
       - run:
           name: pytest
-          command: python3 -m pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock --cov-report=xml --cov-report=html #--cov-fail-under=80
+          command: python -m pytest tests -s --doctest-modules --junitxml=junit/test-results.xml --cov=unmock --cov-report=xml --cov-report=html #--cov-fail-under=80
       - when:
           condition: << parameters.publish >>
           steps:
@@ -28,13 +28,10 @@ commands:
                 path: junit
 
 jobs:
-  build:  # default entry point for CircleCI, test against Python 3.6.8
-    docker:
-      - image: circleci/python:3.6.8
+  # Find tags here: https://circleci.com/docs/2.0/docker-image-tags.json
+  build:  # Default entry point, just see we can actually pull the contents....
     steps:
-    - setup
-    - test:
-        publish: true
+    - checkout
 
   linux27:  # Python 2.7.16
     docker:
@@ -42,6 +39,35 @@ jobs:
     steps:
     - setup
     - test
+
+  linux33:
+    docker:
+      - image: circleci/python:3.3
+    steps:
+    - setup
+    - test
+
+  linux34:
+    docker:
+      - image: circleci/python:3.4
+    steps:
+    - setup
+    - test
+
+  linux35:
+    docker:
+      - image: circleci/python:3.5
+    steps:
+    - setup
+    - test
+
+  linux36:
+    docker:
+      - image: circleci/python:3.6.8
+    steps:
+    - setup
+    - test:
+        publish: true
 
   linux37:  # Python 3.7.5 RC version
     docker:
@@ -84,12 +110,35 @@ workflows:
       - build
       #- macOS36  # Commented out as we don't have that in CircleCI yet
       #- macOS37
-      - linux37
+      - linux27:
+          requires:
+            - build
+      - linux33:
+          requires:
+            - build
+      - linux34:
+          requires:
+            - build
+      - linux35:
+          requires:
+            - build
+      - linux36:
+          requires:
+            - build
+      - linux37:
+          requires:
+            - build
       - deploy:
           requires:
             - build
             #- macOS36
             #- macOS37
+            - linux27
+            - linux33
+            - linux34
+            - linux35
+            - linux36
+            - linux37
             - linux37
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,8 @@ commands:
 jobs:
   # Find tags here: https://circleci.com/docs/2.0/docker-image-tags.json
   build:  # Default entry point, just see we can actually pull the contents....
+    docker:
+      - image: circleci/python:3.6.8
     steps:
     - checkout
 
@@ -93,7 +95,6 @@ jobs:
     steps:
     - setup
     - test
-
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
 
 jobs:
   # Find tags here: https://circleci.com/docs/2.0/docker-image-tags.json
-  build:  # Default entry point, just see we can actually pull the contents....
+  build:  # Default entry point, just to see we can actually pull the contents....
     docker:
       - image: circleci/python:3.6.8
     steps:
@@ -128,7 +128,6 @@ workflows:
             - linux34
             - linux35
             - linux36
-            - linux37
             - linux37
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,13 +42,6 @@ jobs:
     - setup
     - test
 
-  linux33:
-    docker:
-      - image: circleci/python:3.3
-    steps:
-    - setup
-    - test
-
   linux34:
     docker:
       - image: circleci/python:3.4

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,16 @@ REQUIRED = ["requests", "PyYAML"]
 
 DEV = ["twine", "wheel", "pytest", "pytest-cov"]
 
-if sys.version_info[0] < 3:
-    REQUIRED.append("mock")
+# List of support packages needed based on python version used.
+# Tuple format: (version tuple, package to install)
+# The major-minor version should be the version when a package was introduced, so any older version would use the
+#   support package.
+SUPPORT = [
+    ((3, 3), "mock")  # unittest.mock was added in Python 3.3
+]
+for (ver, pkg) in SUPPORT:
+    if sys.version_info < ver:
+        REQUIRED.append(pkg)
 
 # Optional packages
 EXTRAS = {'dev': DEV}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ DESCRIPTION = 'The Unmock Python clent'
 URL = 'https://www.unmock.io/'
 EMAIL = 'dev@meeshkan.com'
 AUTHOR = 'Meeshkan Dev Team'
-REQUIRES_PYTHON = '>=3.6.0'
+REQUIRES_PYTHON = '>=2.7.0,!=3.0*,!=3.1*,!=3.2*'
 SRC_DIR = 'unmock'  # Relative location wrt setup.py
 
 # Required packages.
@@ -27,7 +27,7 @@ ENTRY_POINTS = []
 here = os.path.abspath(os.path.dirname(__file__))
 
 # Import the README and use it as the long-description.
-with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
+with open(os.path.join(here, 'README.md')) as f:
     long_description = '\n' + f.read()
 
 # Load the package's __version__.py module as a dictionary.
@@ -120,7 +120,10 @@ setup(
         'Development Status :: 2 - Pre-Alpha',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -128,8 +128,8 @@ setup(
     include_package_data=True,
     license='Apache 2.0',
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'License :: OSI Approved :: Apache Software License',
+        'Development Status :: 3 - Alpha',
+        'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ DESCRIPTION = 'The Unmock Python clent'
 URL = 'https://www.unmock.io/'
 EMAIL = 'dev@meeshkan.com'
 AUTHOR = 'Meeshkan Dev Team'
-REQUIRES_PYTHON = '>=2.7.0,!=3.0*,!=3.1*,!=3.2*'
+REQUIRES_PYTHON = '>=2.7.0,!=3.0*,!=3.1*,!=3.2*,!=3.3*'
 SRC_DIR = 'unmock'  # Relative location wrt setup.py
 
 # Required packages.
@@ -132,7 +132,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ REQUIRED = ["requests", "PyYAML"]
 
 DEV = ["twine", "wheel", "pytest", "pytest-cov"]
 
+if sys.version_info[0] < 3:
+    REQUIRED.append("mock")
+
 # Optional packages
 EXTRAS = {'dev': DEV}
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,19 +1,11 @@
 import pytest
 import tempfile
-from pathlib import Path
 import shutil
-from typing import Dict, Any
 from unmock.core.persistence import FSPersistence
 
-@pytest.fixture
-def redirect_home_path():
-    FSPersistence.HOMEPATH = Path(tempfile.mkdtemp())
-    yield None
-    shutil.rmtree(FSPersistence.HOMEPATH)
 
-
-def test_correct_body_no_headers(redirect_home_path):
-    prs = FSPersistence("fake_token")
+def test_correct_body_no_headers():
+    prs = FSPersistence("fake_token", path=tempfile.mkdtemp())
     prs.save_body(hash="abc", body='{'
                     '"data": ['
                         '{'

--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -43,5 +43,3 @@ def reset():
     """
     from . import core
     core.http.reset()
-
-del core

--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -3,12 +3,12 @@ from .__version__ import __version__  # Conform to PEP-0396
 from . import pytest
 from .core import UnmockOptions, exceptions
 
-def init(unmock_options: UnmockOptions = None, story=None, refresh_token=None):
+def init(unmock_options=None, story=None, refresh_token=None):
     """Shorthand for initialize"""
     initialize(unmock_options, story, refresh_token)
 
 
-def initialize(unmock_options: UnmockOptions = None, story=None, refresh_token=None) -> UnmockOptions:
+def initialize(unmock_options=None, story=None, refresh_token=None):
     """
     Initialize the unmock library for capturing API calls.
 
@@ -20,10 +20,14 @@ def initialize(unmock_options: UnmockOptions = None, story=None, refresh_token=N
     :param refresh_token: An optional unmock token identifying your account.
     :type refresh_token str
     """
-    from pathlib import Path
+
+    import os
     from . import core  # Imported internally to keep the namespace clear
-    logs_dir = Path.home().joinpath(".unmock").joinpath("logs")
-    logs_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir = os.path.join(os.path.expanduser("~"), ".unmock", "logs")
+    try:
+        os.makedirs(os.path.logs_dir)
+    except OSError:
+        pass  # Directory already exists...
     core.setup_logging(logs_dir)
 
     if story is not None:

--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -24,10 +24,7 @@ def initialize(unmock_options=None, story=None, refresh_token=None):
     import os
     from . import core  # Imported internally to keep the namespace clear
     logs_dir = os.path.join(os.path.expanduser("~"), ".unmock", "logs")
-    try:
-        os.makedirs(os.path.logs_dir)
-    except OSError:
-        pass  # Directory already exists...
+    core.makedirs(logs_dir)
     core.setup_logging(logs_dir)
 
     if story is not None:

--- a/unmock/core/exceptions.py
+++ b/unmock/core/exceptions.py
@@ -1,7 +1,10 @@
-__all__ = ["UnmockException", "UnmockAuthorizationException"]
+__all__ = ["UnmockException", "UnmockAuthorizationException", "UnmockServerUnavailableException"]
 
 class UnmockException(Exception):
     pass
 
-class UnmockAuthorizationException(Exception):
+class UnmockAuthorizationException(UnmockException):
+    pass
+
+class UnmockServerUnavailableException(UnmockException):
     pass

--- a/unmock/core/http.py
+++ b/unmock/core/http.py
@@ -51,7 +51,10 @@ def initialize(unmock_options):
             # Otherwise, we create our own HTTPSConnection to redirect the call to our service when needed.
             # We add the "unmock" attribute to this object and store information for later use.
             uri = parse_url(url)
-            req = http.client.HTTPSConnection(unmock_options.unmock_host, unmock_options.unmock_port)
+            if is_python2():
+                req = httplib.HTTPSConnection(unmock_options.unmock_host, unmock_options.unmock_port)
+            else:
+                req = http.client.HTTPSConnection(unmock_options.unmock_host, unmock_options.unmock_port)
             """
             By order:
             - headers_qp -> contains header information that is used in *q*uery *p*arameters
@@ -60,15 +63,15 @@ def initialize(unmock_options):
             - headers -> actual headers to send to the unmock API
             - method -> actual method to use with the unmock API (always matches the method for the original request)
             """
-            req.__setattr__("unmock_data", { "headers_qp": dict(),
-                                             "path": "{path}?{query}".format(path=uri.path, query=uri.query),
-                                             "story": STORIES,
-                                             "headers": dict(),
-                                             "method": method })
+            setattr(req, "unmock_data", { "headers_qp": dict(),
+                                          "path": "{path}?{query}".format(path=uri.path, query=uri.query),
+                                          "story": STORIES,
+                                          "headers": dict(),
+                                          "method": method })
             if token is not None:  # Add token to official headers
                 # Added as a 1-tuple as the actual call to `putheader` (later on) unpacks it
                 req.unmock_data["headers"]["Authorization"] = ("Bearer {token}".format(token=token), )
-            self.__setattr__("unmock", req)
+            setattr(self, "unmock", req)
 
 
     def unmock_putheader(self, header, *values):
@@ -186,7 +189,7 @@ def initialize(unmock_options):
                                                      story=STORIES, xy=unmock_options._xy(token))
             if new_story is not None:
                 STORIES.append(new_story)
-                res.__setattr__("unmock_hash", new_story)  # So we know the story the response belongs to
+                setattr(res, "unmock_hash", new_story)  # So we know the story the response belongs to
             return res
 
     def unmock_response_read(self, amt=None):

--- a/unmock/core/http.py
+++ b/unmock/core/http.py
@@ -29,12 +29,12 @@ def initialize(unmock_options):
     """
     token = unmock_options.get_token()  # Get the *access_token*
 
-    def unmock_putrequest(self, method, url, skip_host=False, skip_accept_encoding=False):
+    def unmock_putrequest(conn, method, url, skip_host=False, skip_accept_encoding=False):
         """putrequest mock; called initially after the HTTPConnection object has been created. Contains information
         about the endpoint and method.
 
-        :param self
-        :type self HTTPConnection
+        :param conn
+        :type conn HTTPConnection
         :param method
         :type method string
         :param url
@@ -44,10 +44,10 @@ def initialize(unmock_options):
         :param skip_accept_encoding
         :type skip_accept_encoding bool
         """
-        if unmock_options._is_host_whitelisted(self.host):  # Host is whitelisted, redirect to original call.
-            original_putrequest(self, method, url, skip_host, skip_accept_encoding)
+        if unmock_options._is_host_whitelisted(conn.host):  # Host is whitelisted, redirect to original call.
+            original_putrequest(conn, method, url, skip_host, skip_accept_encoding)
 
-        elif not hasattr(self, "unmock"):
+        elif not hasattr(conn, "unmock"):
             # Otherwise, we create our own HTTPSConnection to redirect the call to our service when needed.
             # We add the "unmock" attribute to this object and store information for later use.
             uri = parse_url(url)
@@ -55,14 +55,12 @@ def initialize(unmock_options):
                 req = httplib.HTTPSConnection(unmock_options.unmock_host, unmock_options.unmock_port)
             else:
                 req = http.client.HTTPSConnection(unmock_options.unmock_host, unmock_options.unmock_port)
-            """
-            By order:
-            - headers_qp -> contains header information that is used in *q*uery *p*arameters
-            - path -> stores the endpoint for the request
-            - story -> stores previous access to the unmock service
-            - headers -> actual headers to send to the unmock API
-            - method -> actual method to use with the unmock API (always matches the method for the original request)
-            """
+            # unmock_data dictionary items explained:
+            # - headers_qp -> contains header information that is used in *q*uery *p*arameters
+            # - path -> stores the endpoint for the request
+            # - story -> stores previous access to the unmock service
+            # - headers -> actual headers to send to the unmock API
+            # - method -> actual method to use with the unmock API (always matches the method for the original request)
             setattr(req, "unmock_data", { "headers_qp": dict(),
                                           "path": "{path}?{query}".format(path=uri.path, query=uri.query),
                                           "story": STORIES,
@@ -71,120 +69,122 @@ def initialize(unmock_options):
             if token is not None:  # Add token to official headers
                 # Added as a 1-tuple as the actual call to `putheader` (later on) unpacks it
                 req.unmock_data["headers"]["Authorization"] = ("Bearer {token}".format(token=token), )
-            setattr(self, "unmock", req)
+            setattr(conn, "unmock", req)
 
 
-    def unmock_putheader(self, header, *values):
+    def unmock_putheader(conn, header, *values):
         """putheader mock; called sequentially after the putrequest.
         Here we simply redirect the different headers as either query parameters to be used, to part of the actual
         headers to be used to the unmock request.
 
-        :param self
-        :type self HTTPConnection
+        :param conn
+        :type conn HTTPConnection
         :param header
         :type header string
         :param values
         :type values list, bytes
         """
 
-        if unmock_options._is_host_whitelisted(self.host):  # Host is whitelisted, redirect to original call.
-            original_putheader(self, header, *values)
+        if unmock_options._is_host_whitelisted(conn.host):  # Host is whitelisted, redirect to original call.
+            original_putheader(conn, header, *values)
 
         elif header == "Authorization":  # Authorization is part of the query parameters
-            self.unmock.unmock_data["headers_qp"][header] = values
+            conn.unmock.unmock_data["headers_qp"][header] = values
 
         elif header == UNMOCK_AUTH:  # UNMOCK_AUTH is part of the actual headers
             # TODO: is this ever called...? Where from..?
-            self.unmock.unmock_data["headers"]["Authorization"] = values
+            conn.unmock.unmock_data["headers"]["Authorization"] = values
 
         else:  # Otherwise, we both use it for query parameters and for the actual headers
-            self.unmock.unmock_data["headers_qp"][header] = values
-            self.unmock.unmock_data["headers"][header] = values
+            conn.unmock.unmock_data["headers_qp"][header] = values
+            conn.unmock.unmock_data["headers"][header] = values
 
 
-    def unmock_internal_end_headers(self, message_body):
+    def unmock_internal_end_headers(conn, message_body):
         """
         Performs the internal operations when dealing with the endheaders request.
-        :param self:
-        :type self HTTPConnection
+        :param conn:
+        :type conn HTTPConnection
         :param message_body:
         :param message_body string
         :return:
         """
         # Otherwise we make the actual call to the unmock service
-        unmock_data = self.unmock.unmock_data
+        unmock_data = conn.unmock.unmock_data
         method = unmock_data["method"]
 
         # Builds the query parameters line
-        query = unmock_options._build_query(story=unmock_data["story"], host=self.host, method=method,
+        query = unmock_options._build_query(story=unmock_data["story"], host=conn.host, method=method,
                                             headers=unmock_data["headers_qp"],
                                             path="{path}".format(path=unmock_data["path"]))
 
         # Make the request to the service
-        original_putrequest(self.unmock, method=method,
+        original_putrequest(conn.unmock, method=method,
                             url="{fake_path}?{query}".format(fake_path=unmock_options._xy(token), query=query))
 
         # Add all the actual headers to the request
         for header, value in unmock_data["headers"].items():
-            original_putheader(self.unmock, header, *value)
+            original_putheader(conn.unmock, header, *value)
 
         # Save body and call original endheaders with the body message
-        self.unmock.unmock_data["body"] = message_body
+        conn.unmock.unmock_data["body"] = message_body
 
+    # HTTPResponse.end_headers signature has been changed between Python 2.7 and Python 3.4+, we need to account for it
+    # when mocking
     if is_python2():
-        def unmock_end_headers(self, message_body=None):
+        def unmock_end_headers(conn, message_body=None):
             """endheaders mock; signals the end of the HTTP request.
             At this point we should have all the data to make the request to the unmock service.
 
-            :param self
-            :type self HTTPConnection
+            :param conn
+            :type conn HTTPConnection
             :param message_body
             :type message_body string
             """
-            if unmock_options._is_host_whitelisted(self.host):  # Host is whitelisted, redirect to original call.
+            if unmock_options._is_host_whitelisted(conn.host):  # Host is whitelisted, redirect to original call.
                 # Return to avoid nesting
-                return original_endheaders(self, message_body)
-            unmock_internal_end_headers(self, message_body)
-            original_endheaders(self.unmock, message_body)
+                return original_endheaders(conn, message_body)
+            unmock_internal_end_headers(conn, message_body)
+            original_endheaders(conn.unmock, message_body)
     else:
-        def unmock_end_headers(self, message_body=None, encode_chunked=False):
+        def unmock_end_headers(conn, message_body=None, encode_chunked=False):
             """endheaders mock; signals the end of the HTTP request.
             At this point we should have all the data to make the request to the unmock service.
             NOTE: We drop the bare asterisk for Python2 compatibility.
             See https://stackoverflow.com/questions/2965271/forced-naming-of-parameters-in-python/14298976#14298976
 
-            :param self
-            :type self HTTPConnection
+            :param conn
+            :type conn HTTPConnection
             :param message_body
             :type message_body string
             :param encode_chunked
             :type encode_chunked bool
             """
 
-            if unmock_options._is_host_whitelisted(self.host):  # Host is whitelisted, redirect to original call.
+            if unmock_options._is_host_whitelisted(conn.host):  # Host is whitelisted, redirect to original call.
                 # Return to avoid nesting
-                return original_endheaders(self, message_body, encode_chunked=encode_chunked)
-            unmock_internal_end_headers(self, message_body)
-            original_endheaders(self.unmock, message_body, encode_chunked=encode_chunked)
+                return original_endheaders(conn, message_body, encode_chunked=encode_chunked)
+            unmock_internal_end_headers(conn, message_body)
+            original_endheaders(conn.unmock, message_body, encode_chunked=encode_chunked)
 
 
-    def unmock_get_response(self):
+    def unmock_get_response(conn):
         """getresponse mock; fetches the response from the connection made.
         Here we just need to redirect and use the getresponse from the linked unmock connection, output some messages
         and update the stories.
 
-        :param self
-        :type self HTTPConnection
+        :param conn
+        :type conn HTTPConnection
         """
-        if unmock_options._is_host_whitelisted(self.host):  # Host is whitelisted, redirect to original call.
-            return original_getresponse(self)
+        if unmock_options._is_host_whitelisted(conn.host):  # Host is whitelisted, redirect to original call.
+            return original_getresponse(conn)
 
-        elif hasattr(self, "unmock"):
-            unmock_data = self.unmock.unmock_data
+        elif hasattr(conn, "unmock"):
+            unmock_data = conn.unmock.unmock_data
             # Get unmocked response
-            res = original_getresponse(self.unmock)  # type: HTTPResponse
+            res = original_getresponse(conn.unmock)  # type: HTTPResponse
             # Report the unmocked response, URL, and updates stories
-            new_story = unmock_options._end_reporter(res=res, data=unmock_data["body"], host=self.host,
+            new_story = unmock_options._end_reporter(res=res, data=unmock_data["body"], host=conn.host,
                                                      method=unmock_data["method"], path=unmock_data["path"],
                                                      story=STORIES, xy=unmock_options._xy(token))
             if new_story is not None:
@@ -192,19 +192,19 @@ def initialize(unmock_options):
                 setattr(res, "unmock_hash", new_story)  # So we know the story the response belongs to
             return res
 
-    def unmock_response_read(self, amt=None):
+    def unmock_response_read(res, amt=None):
         """HTTPResponse.read mock; helps save the body of the unmock response locally if it is so desired.
         Since TCP sockets are one-time-transport, we need to catch the read operation and use it then, so nothing is
         missed.
 
-        :param self
-        :type self HTTPResponse
+        :param res
+        :type res HTTPResponse
         :param amt
         :type amt int
         """
-        s = original_response_read(self, amt)
-        if hasattr(self, "unmock_hash"):  # We can now save the body of the content if it exists
-            unmock_options._save_body(self.unmock_hash, str(s.decode()))
+        s = original_response_read(res, amt)
+        if hasattr(res, "unmock_hash"):  # We can now save the body of the content if it exists
+            unmock_options._save_body(res.unmock_hash, str(s.decode()))  # str() to transform from Python2's unicode
         return s
 
     # Create the patchers and mock away!

--- a/unmock/core/http.py
+++ b/unmock/core/http.py
@@ -1,8 +1,8 @@
 from .utils import Patchers, parse_url, is_python2
-if is_python2():
-    import httplib
-else:
+try:
     import http.client
+except ImportError:
+    import httplib
 import os
 
 from . import PATCHERS, STORIES
@@ -204,7 +204,7 @@ def initialize(unmock_options):
         """
         s = original_response_read(self, amt)
         if hasattr(self, "unmock_hash"):  # We can now save the body of the content if it exists
-            unmock_options._save_body(self.unmock_hash, s.decode())
+            unmock_options._save_body(self.unmock_hash, str(s.decode()))
         return s
 
     # Create the patchers and mock away!
@@ -221,4 +221,4 @@ def initialize(unmock_options):
 
 def reset():
     PATCHERS.clear()
-    STORIES.clear()
+    del STORIES[:]

--- a/unmock/core/logger.py
+++ b/unmock/core/logger.py
@@ -1,28 +1,27 @@
 import logging
 import logging.config
-from pathlib import Path
+import os
 
 import yaml
 
 __all__ = ["setup_logging"]
 
-LOG_CONFIG_FILE = Path(__file__).absolute().parent.joinpath("logging.yaml")
+LOG_CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logging.yaml")
 
-def setup_logging(logs_dir: Path, log_config: Path = LOG_CONFIG_FILE):
+def setup_logging(logs_dir, log_config=LOG_CONFIG_FILE):
     """Setup logging configuration
     This MUST be called before creating any loggers.
     """
-    if not log_config.is_file():
+    if not os.path.isfile(log_config):
         raise RuntimeError("Logging file {log_file} not found".format(log_file=log_config))
 
-    with log_config.open() as log_file:
+    with open(log_config) as log_file:
         config = yaml.safe_load(log_file.read())
 
     # Prepend `LOGS_DIR` to all 'filename' attributes listed for handlers in logging.yaml
     for handler_name in config['handlers'].keys():
         handler_config = config['handlers'][handler_name]
         if 'filename' in handler_config:
-            filename = Path(handler_config['filename']).name
-            handler_config['filename'] = str(logs_dir.joinpath(filename))
+            handler_config['filename'] = os.path.joinpath(logs_dir, handler_config['filename'])
 
     logging.config.dictConfig(config)

--- a/unmock/core/logger.py
+++ b/unmock/core/logger.py
@@ -22,6 +22,6 @@ def setup_logging(logs_dir, log_config=LOG_CONFIG_FILE):
     for handler_name in config['handlers'].keys():
         handler_config = config['handlers'][handler_name]
         if 'filename' in handler_config:
-            handler_config['filename'] = os.path.joinpath(logs_dir, handler_config['filename'])
+            handler_config['filename'] = os.path.join(logs_dir, handler_config['filename'])
 
     logging.config.dictConfig(config)

--- a/unmock/core/options.py
+++ b/unmock/core/options.py
@@ -1,4 +1,3 @@
-from typing import Union, List, Optional, Dict, Any, cast
 from urllib.parse import urlencode
 from http.client import HTTPResponse
 from http import HTTPStatus
@@ -7,6 +6,7 @@ import logging
 import json
 import requests
 
+from .logger import setup_logging
 from .persistence import FSPersistence, Persistence
 from .utils import parse_url
 from .exceptions import UnmockAuthorizationException
@@ -17,12 +17,58 @@ UNMOCK_HOST = "api.unmock.io"
 UNMOCK_PORT = 443
 
 class UnmockOptions:
-    def __init__(self, save: Union[bool, List[str]] = False, unmock_host: str = UNMOCK_HOST, unmock_port = UNMOCK_PORT,
-                 use_in_production: bool = False, path: Optional[Union[str, Path]] = None,
-                 logger: Optional[logging.Logger] = None, persistence: Optional[Persistence] = None,
-                 ignore=None, signature: Optional[str] = None, token: Optional[str] = None,
-                 whitelist: Optional[List[str]] = None):
+    def __init__(self, save=False, unmock_host=UNMOCK_HOST, unmock_port=UNMOCK_PORT, use_in_production=False,
+                 storage_path=None, logger=None, persistence=None, ignore=None, signature=None, token=None,
+                 whitelist=None):
+        """
+        Creates a new UnmockOptions object, customizing the use of Unmock service
+        :param save: whether or not to save all mocks (when using boolean value), or a list of specific story IDs to
+            save. Deafult to False.
+        :type save boolean, list of strings
+
+        :param unmock_host: The URL for unmock host, if it is on prem. Default to api.unmock.io
+        :type unmock_host string
+
+        :param unmock_port: The port for unmock host, if it s on prem. Default to 443.
+        :type unmock_port int
+
+        :param use_in_production: Whether or not to use unmock in production, based on `ENV` environment variable.
+            Default to False.
+        :type use_in_production boolean
+
+        :param storage_path: Location where mocks (and credentials, etc) should be stored. Creates a hidden `.unmock`
+            directory in that location to store relevant data. Only relevant when saving some of the data.
+            Default to None (uses home directory).
+        :type storage_path string
+
+        :param logger: A logger file if a user wants to redirect/manage logs in that non-default way. Defaults to a
+            console logger, with `info.log` and `debug.log` in a logs directory located in the storage_path.
+        :type logger logging.Logger
+
+        :param persistence: A type of persistence layer, can be used to e.g. save mocks automatically to S3 buckets or
+            on local disk. Defaults to None and uses file system to store credentials, mocks (if save is defined), etc.
+        :type persistence Persistence
+
+        :param ignore: A string, list, dictionary or a combination of them, specifying different parameters to ignore
+            when serving mocks. See the documentation for more details.
+        :type string, list, dictionary, any
+
+        :param signature: An optional signature allowing a user to have specific mocks for different purposes.
+            The signature is used when computing the story hash; see the documentation for more details.
+        :type string
+
+        :param token: An optional refresh token, given when you sign up to the unmock service. With a valid token, you
+            can have unlimited calls to the unmock service, an online dashboard, private mocks, etc.
+        :type string
+
+        :param whitelist: An optional list (or string) of URLs to whitelist, so that you may access them without unmock
+            intercepting the calls. Defaults to ["127.0.0.1", "127.0.0.0", "localhost"]
+        :type string, list of strings
+
+        """
         if logger is None:
+            if storage_path is not None:
+                setup_logging(storage_path)
             logger = logging.getLogger("unmock.reporter")
         self.logger = logger
         self.save = save
@@ -43,7 +89,7 @@ class UnmockOptions:
         # Add the unmock host to whitelist:
         self.whitelist.append(unmock_host)
         if persistence is None:
-            persistence = FSPersistence(self.token, path=path)
+            persistence = FSPersistence(self.token, path=storage_path)
         self.persistence = persistence
 
     def ignore(self, *args, **kwargs):

--- a/unmock/core/persistence.py
+++ b/unmock/core/persistence.py
@@ -1,12 +1,13 @@
 from abc import ABCMeta, abstractmethod
 import json
 import os
-
-from .utils import is_python2, makedirs
-if is_python2():
-    import ConfigParser as configparser
-else:
+try:
     import configparser
+except ImportError:
+    import ConfigParser as configparser
+    json.JSONDecodeError = ValueError  # Python 2.7's json throws ValueError and has not JSONDecodeError
+
+from .utils import makedirs
 
 __all__ = ["FSPersistence", "Persistence"]
 

--- a/unmock/core/persistence.py
+++ b/unmock/core/persistence.py
@@ -97,7 +97,7 @@ class FSPersistence(Persistence):
     def __init__(self, token, path=None):
         super(FSPersistence, self).__init__(token)
         self.homepath = os.path.abspath(path or os.path.expanduser("~"))  # Given directory or home path
-        self.unmock_dir.mkdir(parents=True, exist_ok=True)  # Create home directory if needed
+        makedirs(self.unmock_dir)  # Create home directory if needed
         # Maps unmock hashes (string) to partial json body (string), when body is read in chunks
         self.partial_body_jsons = dict()
 

--- a/unmock/core/utils.py
+++ b/unmock/core/utils.py
@@ -1,18 +1,20 @@
 import sys
 import os
 import json
-
-def is_python2():
-    return sys.version_info[0] < 3
-
-if is_python2():
-    from urlparse import urlsplit, SplitResult
-    import mock
-else:
+try:
     from urllib.parse import urlsplit, SplitResult
+except ImportError:
+    from urlparse import urlsplit, SplitResult
+try:
     from unittest import mock
+except ImportError:
+    import mock
 
 __all__ = ["Patchers", "parse_url", "is_python2", "makedirs"]
+
+def is_python2():
+    """ Recommended way to import is with try-except; this shorthand is made for where we're not importing modules. """
+    return sys.version_info[0] < 3
 
 class Patchers:
     """Represents a collection of mock.patcher objects to be started/stopped simulatenously."""
@@ -37,8 +39,8 @@ class Patchers:
         """Stop any ongoing patches and clears the list of patchers in this instance"""
         if self.patchers:
             self.stop()
-        self.patchers.clear()
-        self.targets.clear()
+        del self.patchers[:]
+        del self.targets[:]
 
     def start(self):
         """Starts all registered patchers"""

--- a/unmock/core/utils.py
+++ b/unmock/core/utils.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import json
 
 def is_python2():
@@ -11,7 +12,7 @@ else:
     from urllib.parse import urlsplit, SplitResult
     from unittest import mock
 
-__all__ = ["Patchers", "parse_url", "is_python2"]
+__all__ = ["Patchers", "parse_url", "is_python2", "makedirs"]
 
 class Patchers:
     """Represents a collection of mock.patcher objects to be started/stopped simulatenously."""
@@ -56,3 +57,10 @@ def parse_url(url):
         # To make `urlsplit` work we need to provide the protocol; this is arbitrary (and can even be "//")
         return urlsplit("https://{url}".format(url=url))
     return parsed_url
+
+def makedirs(path):
+    """Quiet makedirs (similar to Python3 ok_exists=True flag)"""
+    try:
+        os.makedirs(path)
+    except OSError:
+        pass

--- a/unmock/core/utils.py
+++ b/unmock/core/utils.py
@@ -1,10 +1,17 @@
-from typing import List, Dict, Any, Union
-from collections.abc import Iterable
+import sys
 import json
-from urllib.parse import urlsplit, SplitResult
-from unittest import mock
 
-__all__ = ["Patchers", "parse_url"]
+def is_python2():
+    return sys.version_info[0] < 3
+
+if is_python2():
+    from urlparse import urlsplit, SplitResult
+    import mock
+else:
+    from urllib.parse import urlsplit, SplitResult
+    from unittest import mock
+
+__all__ = ["Patchers", "parse_url", "is_python2"]
 
 class Patchers:
     """Represents a collection of mock.patcher objects to be started/stopped simulatenously."""
@@ -42,7 +49,8 @@ class Patchers:
         for patcher in self.patchers:
             patcher.stop()
 
-def parse_url(url) -> SplitResult:
+def parse_url(url):
+    """Parses a url using urlsplit, returning a SplitResult. Adds https:// scheme if netloc is empty."""
     parsed_url = urlsplit(url)
     if parsed_url.scheme == "" or parsed_url.netloc == "":
         # To make `urlsplit` work we need to provide the protocol; this is arbitrary (and can even be "//")


### PR DESCRIPTION
To address #6:
- Removes dependency on `pathlib` (achieving same results with `os`).
- Removes typing (will have to add typing tests with mypy in a following PR).
- Modifies setup.py and import statements to match Python 2.7
- **Bonus** adds wildcard matching for whitelist