### PR TITLE
[Core] Pytest plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,9 @@ commands:
       - run:
           name: Pytest Plugin
           command: |
-            pytest tests/plugin_text.py
-            USE_UNMOCK=True pytest tests/plugin_text.py || echo "Failed successfully!"
-            USE_UNMOCK=True pytest tests/plugin_text.py --unmock
+            pytest tests/plugin_test.py
+            USE_UNMOCK=True pytest tests/plugin_test.py || echo "Failed successfully!"
+            USE_UNMOCK=True pytest tests/plugin_test.py --unmock
       - when:
           condition: << parameters.publish >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,15 @@ commands:
       - run:
           name: Pytest
           command: |
-            coverage run --source unmock -m pytest --junitxml=junit/test-results.xml
+            coverage run --source unmock -m pytest --junitxml=junit/test-results.xml --ignore-glob=*/plugin_test.py
             coverage html --fail-under=80
             coverage xml
+      - run:
+          name: Pytest Plugin
+          command: |
+            pytest tests/plugin_text.py
+            USE_UNMOCK=True pytest tests/plugin_text.py || echo "Failed successfully!"
+            USE_UNMOCK=True pytest tests/plugin_text.py --unmock
       - when:
           condition: << parameters.publish >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,7 @@ commands:
                 path: junit
             - store_artifacts:
                 path: htmlcov
-            - codecov/upload:
-                conf: codecov.yml
+            - codecov/upload
 
 jobs:
   # Find tags here: https://circleci.com/docs/2.0/docker-image-tags.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ commands:
             # Should succeed - expected to raise a warning and catch it with pytest
             pytest tests/plugin_test.py
             # Test should fail (so we inverse exit codes)
-            bash -c "USE_UNMOCK=True pytest -sx tests/plugin_test.py; if [[ $? -eq 0 ]] ; then exit 1 ; else exit 0 ; fi"
+            bash -c "USE_UNMOCK=True pytest -sx tests/plugin_test.py; if [[ \$? -eq 0 ]] ; then exit 1 ; else exit 0 ; fi"
             # Test should succeed - unmock up and running
             USE_UNMOCK=True pytest tests/plugin_test.py --unmock
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,8 @@ commands:
                 path: junit
             - store_artifacts:
                 path: htmlcov
-            - codecov/upload
+            - codecov/upload:
+                conf: codecov.yml
 
 jobs:
   # Find tags here: https://circleci.com/docs/2.0/docker-image-tags.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,11 @@ commands:
       - run:
           name: Pytest Plugin
           command: |
+            # Should succeed - expected to raise a warning and catch it with pytest
             pytest tests/plugin_test.py
-            USE_UNMOCK=True pytest tests/plugin_test.py || echo "Failed successfully!"
+            # Test should fail (so we inverse exit codes)
+            bash -c "USE_UNMOCK=True pytest -sx tests/plugin_test.py; if [[ $? -eq 0 ]] ; then exit 1 ; else exit 0 ; fi"
+            # Test should succeed - unmock up and running
             USE_UNMOCK=True pytest tests/plugin_test.py --unmock
       - when:
           condition: << parameters.publish >>

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+comment:
+  layout: "diff, files"
+  require_changes: yes

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,0 @@
-comment:
-  layout: "diff, files"
-  require_changes: yes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,8 @@ def tmpdir():
 @pytest.fixture
 def unmock_and_reset():
     def init(**kwargs):
-        default_kwargs = {"token": get_token(), "logger": get_logger()}
+        default_kwargs = {"refresh_token": get_token(), "logger": get_logger()}
         default_kwargs.update(kwargs)
-        opts = unmock.UnmockOptions(**default_kwargs)
-        unmock.init(opts)
-        return opts
+        return unmock.init(**default_kwargs)
     yield init
     unmock.reset()

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -1,0 +1,15 @@
+"""Named without test_ in the beginning so we can test manually"""
+
+import requests
+import os
+
+TIMEOUT = 10
+
+def test_pytest_flag():
+    response = requests.get("http://www.example.com/", timeout=TIMEOUT)  # Nothing here anyway
+    if os.environ.get("USE_UNMOCK"):
+        assert response.json()  # Will throw as response is not json
+    else:
+        import pytest
+        with pytest.raises(Exception):
+            assert response.json()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,7 @@ def test_init_and_reset():
     unmock.reset()
     assert len(unmock_core.PATCHERS.targets) == len(unmock_core.PATCHERS.patchers) == 0
 
-    unmock.init(unmock.UnmockOptions(save=True))
+    unmock.init(save=True)
     assert len(unmock_core.PATCHERS.targets) == len(unmock_core.PATCHERS.patchers) == 5
     unmock.reset()
     assert len(unmock_core.PATCHERS.targets) == len(unmock_core.PATCHERS.patchers) == 0

--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -12,6 +12,16 @@ TIMEOUT = 10
 URL = "https://www.behance.net/v2/projects"
 API = "?api_key=u_n_m_o_c_k_200"
 
+def test_pytest_default(unmock):
+    response = requests.get("http://www.example.com/", timeout=TIMEOUT)  # Nothing here anyway
+    assert response.json()
+
+
+def test_pytest_init(unmock, tmpdir):
+    unmock(storage_path=tmpdir, save=True)
+    response = requests.get("http://www.example.com/", timeout=TIMEOUT)  # Nothing here anyway
+    assert response.json()
+
 
 def test_no_credentials_no_signature(unmock_and_reset):
     unmock_and_reset(**{"token": None})

--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -12,17 +12,6 @@ TIMEOUT = 10
 URL = "https://www.behance.net/v2/projects"
 API = "?api_key=u_n_m_o_c_k_200"
 
-def test_pytest_default(unmock):
-    response = requests.get("http://www.example.com/", timeout=TIMEOUT)  # Nothing here anyway
-    assert response.json()
-
-
-def test_pytest_init(unmock, tmpdir):
-    unmock(storage_path=tmpdir, save=True)
-    response = requests.get("http://www.example.com/", timeout=TIMEOUT)  # Nothing here anyway
-    assert response.json()
-
-
 def test_no_credentials_no_signature(unmock_and_reset):
     unmock_and_reset(refresh_token=None)
     response = requests.get("http://www.example.com/", timeout=TIMEOUT)  # Nothing here anyway
@@ -76,7 +65,7 @@ def test_hubapi(unmock_and_reset):
 
 def test_no_story(unmock_and_reset):
     # Adds story to ignore list
-    opts = unmock_and_reset(**{"ignore": "story", "save": True})
+    opts = unmock_and_reset(ignore="story", save=True)
     mocked_save_headers = mock.MagicMock()
     mocked_save_body = mock.MagicMock()
     opts.persistence.save_headers = mocked_save_headers

--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -24,13 +24,13 @@ def test_pytest_init(unmock, tmpdir):
 
 
 def test_no_credentials_no_signature(unmock_and_reset):
-    unmock_and_reset(**{"token": None})
+    unmock_and_reset(refresh_token=None)
     response = requests.get("http://www.example.com/", timeout=TIMEOUT)  # Nothing here anyway
     assert response.json()
 
 
 def test_no_credentials_with_signature(unmock_and_reset):
-    opts = unmock_and_reset(**{"signature": "boom", "token": None})
+    opts = unmock_and_reset(signature="boom", refresh_token=None)
     assert opts.persistence.token is None
     response = requests.get("{url}{api}".format(url=URL, api=API), timeout=TIMEOUT)
     projects = response.json().get("projects")

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -12,11 +12,11 @@ from .utils import one_hit_server, get_token, MockResponse
 
 def test_default_logger(tmpdir):
     opts = UnmockOptions()
-    logger = opts.logger
+    logger = opts._logger
     assert logger.getEffectiveLevel() == logging.DEBUG
     assert logger.name == "unmock.reporter"
     opts = UnmockOptions(storage_path=tmpdir)
-    handlers = opts.logger.parent.handlers  # Handlers are set for unmock, not unmock.*
+    handlers = opts._logger.parent.handlers  # Handlers are set for unmock, not unmock.*
     assert handlers
     for handler in handlers:
         if isinstance(handler, logging.handlers.RotatingFileHandler):
@@ -40,7 +40,6 @@ def test_whitelist_local():
 
 def test_credentials_with_token(tmpdir):
     opts = UnmockOptions(storage_path=tmpdir)
-    assert opts.token is None
     assert opts.persistence.token is None
     with open(opts.persistence.config_path, 'w') as cnfgfd:
         cnfgfd.writelines(["[unmock]\ntoken={tok}\n".format(tok=get_token())])
@@ -69,14 +68,14 @@ def test_get_token_errors(tmpdir):
         requests_get_patch.side_effect = lambda _, headers: MockResponse({}, status_code=0)
         with pytest.raises(unmock_exceptions.UnmockAuthorizationException,
                            match="Internal authorization error"):  # get_token called on init
-            UnmockOptions(token=PSEUDO_TOKEN, storage_path=tmpdir)
+            UnmockOptions(refresh_token=PSEUDO_TOKEN, storage_path=tmpdir)
 
         requests_post_patch.side_effect = mocked_post(MockResponse({}))
         with pytest.raises(unmock_exceptions.UnmockAuthorizationException,
                            match="Incorrect server response: did not get accessToken"):
-            UnmockOptions(token=PSEUDO_TOKEN, storage_path=tmpdir)
+            UnmockOptions(refresh_token=PSEUDO_TOKEN, storage_path=tmpdir)
 
         requests_post_patch.side_effect = mocked_post(MockResponse({}, status_code=0))
         with pytest.raises(unmock_exceptions.UnmockAuthorizationException,
                            match="Internal authorization error, receieved"):
-            UnmockOptions(token=PSEUDO_TOKEN, storage_path=tmpdir)
+            UnmockOptions(refresh_token=PSEUDO_TOKEN, storage_path=tmpdir)

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -1,0 +1,15 @@
+import unmock
+
+def test_pytest_local(unmock_local):
+    assert unmock.is_mocking()
+
+
+def test_pytest_local_reinit(unmock_local, tmpdir):
+    assert unmock.is_mocking()
+    opts = unmock_local(storage_path=tmpdir, save=True)
+    assert tmpdir in opts.persistence.hash_dir
+    assert unmock.is_mocking()
+
+
+def test_pytest_local1():
+    assert not unmock.is_mocking()  # Not using the unmock_global fixture, unmock has not been called

--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -3,29 +3,59 @@ from .__version__ import __version__  # Conform to PEP-0396
 from . import pytest
 from .core import UnmockOptions, exceptions
 
-def init(unmock_options=None, story=None, refresh_token=None):
+def init(**kwargs):
     """Shorthand for initialize"""
-    return initialize(unmock_options, story, refresh_token)
+    return initialize(**kwargs)
 
 
-def initialize(unmock_options=None, story=None, refresh_token=None):
+def initialize(**kwargs):
     """
     Initialize the unmock library for capturing API calls.
+    Pass keyword arguments to be used for internal options:
 
-    :param unmock_options: An Optional object allowing customization of how unmock works.
-    :type unmock_options UnmockOptions
-    :param story: An optional list of unmock stories to initialize the state. These represent previous calls to unmock
-        and make unmock stateful.
-    :type story List[str]
-    :param refresh_token: An optional unmock token identifying your account.
-    :type refresh_token str
+    :param save: whether or not to save all mocks (when using boolean value), or a list of specific story IDs to
+        save. Deafult to False.
+    :type save boolean, list of strings
+
+    :param use_in_production: Whether or not to use unmock in production, based on `ENV` environment variable.
+        Default to False.
+    :type use_in_production boolean
+
+    :param storage_path: Location where mocks (and credentials, etc) should be stored. Creates a hidden `.unmock`
+        directory in that location to store relevant data. Only relevant when saving some of the data.
+        Default to None (uses home directory).
+    :type storage_path string
+
+    :param logger: A logger file if a user wants to redirect/manage logs in that non-default way. Defaults to a
+        console logger, with `info.log` and `debug.log` in a logs directory located in the storage_path.
+    :type logger logging.Logger
+
+    :param persistence: A type of persistence layer, can be used to e.g. save mocks automatically to S3 buckets or
+        on local disk. Defaults to None and uses file system to store credentials, mocks (if save is defined), etc.
+    :type persistence Persistence
+
+    :param ignore: A string, list, dictionary or a combination of them, specifying different parameters to ignore
+        when serving mocks. See the documentation for more details.
+    :type string, list, dictionary, any
+
+    :param signature: An optional signature allowing a user to have specific mocks for different purposes.
+        The signature is used when computing the story hash; see the documentation for more details.
+    :type string
+
+    :param refresh_token: An optional refresh token, given when you sign up to the unmock service. With a valid token,
+        you can have unlimited calls to the unmock service, an online dashboard, private mocks, etc.
+    :type string
+
+    :param whitelist: An optional list (or string) of URLs to whitelist, so that you may access them without unmock
+        intercepting the calls. Defaults to ["127.0.0.1", "127.0.0.0", "localhost"]
+    :type string, list of strings
     """
 
     from . import core  # Imported internally to keep the namespace clear
-    if story is not None:
-        core.STORIES += story
-    if unmock_options is None:  # Default then!
-        unmock_options = UnmockOptions(token=refresh_token)
+    new_stories = kwargs.get("story")
+    if new_stories is not None:
+        core.STORIES += new_stories if isinstance(new_stories, list) else [new_stories]
+    unmock_options = UnmockOptions(**kwargs)
 
     core.http.initialize(unmock_options)
 

--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -68,3 +68,11 @@ def reset():
     """
     from . import core
     core.http.reset()
+
+
+def is_mocking():
+    """
+    Returns whether or not unmock is currently capturing calls
+    """
+    from . import core
+    return len(core.PATCHERS.targets) > 0

--- a/unmock/core/__init__.py
+++ b/unmock/core/__init__.py
@@ -10,5 +10,5 @@ from .http import *
 from .logger import *
 from . import exceptions
 
-__all__ = ["initialize", "reset", "UnmockOptions", "exceptions"]
+__all__ = ["initialize", "reset", "exceptions"]
 

--- a/unmock/core/http.py
+++ b/unmock/core/http.py
@@ -47,7 +47,7 @@ def initialize(unmock_options):
             # Otherwise, we create our own HTTPSConnection to redirect the call to our service when needed.
             # We add the "unmock" attribute to this object and store information for later use.
             uri = parse_url(url)
-            req = http_client.HTTPSConnection(unmock_options.unmock_host, unmock_options.unmock_port,
+            req = http_client.HTTPSConnection(unmock_options._unmock_host, unmock_options._unmock_port,
                                               timeout=conn.timeout)
             # unmock_data dictionary items explained:
             # - headers_qp -> contains header information that is used in *q*uery *p*arameters

--- a/unmock/core/options.py
+++ b/unmock/core/options.py
@@ -224,6 +224,7 @@ class UnmockOptions:
             self.logger.info("We've sent you mock data back. You can edit your mock at https://unmock.io%s%s.", xy,
                              unmock_hash)
             if (self.save == True) or (isinstance(self.save, list) and unmock_hash in self.save):
+                self.logger.info("Mocked data was also saved locally at %s", self.persistence._outdir(unmock_hash))
                 self.persistence.save_headers(hash=unmock_hash, headers=dict(res.getheaders()))
             return unmock_hash
 

--- a/unmock/core/persistence.py
+++ b/unmock/core/persistence.py
@@ -116,7 +116,7 @@ class FSPersistence(Persistence):
     def hash_dir(self):
         return os.path.join(self.unmock_dir, "save")
 
-    def __outdir(self, hash):
+    def _outdir(self, hash):
         hashdir = os.path.join(self.hash_dir, hash)
         makedirs(hashdir)
         return hashdir
@@ -132,7 +132,7 @@ class FSPersistence(Persistence):
         :type dictionary, string
         """
         if content is not None:
-            with open(os.path.join(self.__outdir(hash), filename), 'w') as fp:
+            with open(os.path.join(self._outdir(hash), filename), 'w') as fp:
                 json.dump(content, fp, indent=2)
                 fp.flush()
 
@@ -146,7 +146,7 @@ class FSPersistence(Persistence):
         :return: The decoded content from filename if successful, None otherwise
         """
         try:
-            with open(os.path.join(self.__outdir(hash), filename)) as fp:
+            with open(os.path.join(self._outdir(hash), filename)) as fp:
                 return json.load(fp)
         except (json.JSONDecodeError, OSError, IOError):
             # JSONDecode when it fails decoding content

--- a/unmock/pytest/plugin.py
+++ b/unmock/pytest/plugin.py
@@ -1,1 +1,14 @@
 """A pytest plugin for Unmock"""
+import pytest
+from .. import init, reset, UnmockOptions
+
+@pytest.fixture
+def unmock():
+    def _init(**kwargs):
+        opts = UnmockOptions(**kwargs)
+        reset()
+        init(opts)
+        return opts
+    init()
+    yield _init
+    reset()

--- a/unmock/pytest/plugin.py
+++ b/unmock/pytest/plugin.py
@@ -2,11 +2,23 @@
 import pytest
 from .. import init, reset, UnmockOptions
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def unmock():
+    """Initialized ONCE per module, saving time on pinging host etc"""
     def _init(**kwargs):
         reset()
         return init(**kwargs)
     init()
     yield _init
     reset()
+
+@pytest.fixture(scope="function")
+def unmock_local():
+    """Initializes the unmock service whenever used in any function"""
+    def _init(**kwargs):
+        reset()
+        return init(**kwargs)
+    init()
+    yield _init
+    reset()
+

--- a/unmock/pytest/plugin.py
+++ b/unmock/pytest/plugin.py
@@ -2,15 +2,6 @@
 import pytest
 from .. import init, reset, UnmockOptions
 
-@pytest.fixture(scope="module")
-def unmock():
-    """Initialized ONCE per module, saving time on pinging host etc"""
-    def _init(**kwargs):
-        reset()
-        return init(**kwargs)
-    init()
-    yield _init
-    reset()
 
 @pytest.fixture(scope="function")
 def unmock_local():
@@ -22,3 +13,17 @@ def unmock_local():
     yield _init
     reset()
 
+
+def pytest_addoption(parser):
+    parser.addoption("--unmock", dest="USE_UNMOCK", action="store_true",
+                     help="Use Unmock (with default settings) to capture and mock 3rd party API calls")
+
+
+def pytest_configure(config):
+    if config.getoption("USE_UNMOCK"):
+        init()
+
+
+def pytest_unconfigure(config):  # Cleanup
+    if config.getoption("USE_UNMOCK"):
+        reset()

--- a/unmock/pytest/plugin.py
+++ b/unmock/pytest/plugin.py
@@ -5,10 +5,8 @@ from .. import init, reset, UnmockOptions
 @pytest.fixture
 def unmock():
     def _init(**kwargs):
-        opts = UnmockOptions(**kwargs)
         reset()
-        init(opts)
-        return opts
+        return init(**kwargs)
     init()
     yield _init
     reset()


### PR DESCRIPTION
With unmock installed and used with pytest, one does not even need to `import unmock` now - it is passed as a fixture.
- There is one fixture available - `unmock_local` (to emphasize that the service is initialized for the scope of the function). For wider use, people may use `unmock.init()` in higher level scope (#20)
- Adds a `--unmock` flag to pytest command line (unmock runs throughout the entire test suite unless it's manually `reset`)
- `init` now accepts `kwargs` that are passed to `UnmockOptions` (#19)
- Adds a `is_mocking` function to see if unmock is currently capturing API calls