### PR TITLE
[Fix] Save the response body in chunked response

### DIFF
--- a/unmock/core/options.py
+++ b/unmock/core/options.py
@@ -254,6 +254,8 @@ class UnmockOptions:
         :type string
         """
         if unmock_hash is not None and unmock_hash not in story:
-            if (self.save == True) or (isinstance(self.save, list) and unmock_hash in self.save):
-                self.persistence.save_body(hash=unmock_hash, body=body)
-            return unmock_hash
+            if body is None or self.save == False or (isinstance(self.save, list) and unmock_hash not in self.save):
+                # No content or nothing to save, so saving the mocked data "done"
+                return unmock_hash
+            if self.persistence.save_body(hash=unmock_hash, body=body):
+                return unmock_hash  # Only return the hash once we have a successful write

--- a/unmock/core/persistence.py
+++ b/unmock/core/persistence.py
@@ -124,6 +124,7 @@ class FSPersistence(Persistence):
     def __write_to_hashed(self, hash, filename, content):
         """
         Writes given content to the given filename, to be located in the relevant hash directory
+        Returns True upon successful write, False otherwise.
         :param hash: A story hash
         :type hash string
         :param filename: The filename to use when saving
@@ -135,6 +136,8 @@ class FSPersistence(Persistence):
             with open(os.path.join(self._outdir(hash), filename), 'w') as fp:
                 json.dump(content, fp, indent=2)
                 fp.flush()
+            return True
+        return False
 
     def __load_from_hashed(self, hash, filename):
         """
@@ -149,7 +152,7 @@ class FSPersistence(Persistence):
             with open(os.path.join(self._outdir(hash), filename)) as fp:
                 return json.load(fp)
         except (json.JSONDecodeError, OSError, IOError):
-            # JSONDecode when it fails decoding content
+            # JSONDecoder when it fails decoding content
             # OSError is for when the file is not found on Python3
             # IOError for when file is not found on Python2
             # Raise on other errors
@@ -171,7 +174,7 @@ class FSPersistence(Persistence):
                 del self.partial_body_jsons[hash]  # Success! Remove the partial's cache
             except json.JSONDecodeError:
                 body = None  # Failed! Don't access disk just yet...
-        self.__write_to_hashed(hash=hash, filename=FSPersistence.BODY_FILE, content=body)
+        return self.__write_to_hashed(hash=hash, filename=FSPersistence.BODY_FILE, content=body)
 
     def save_auth(self, auth):
         with open(self.token_path, 'w') as tknfd:


### PR DESCRIPTION
Writing the response body now returns a boolean so we can verify when the content has actually been written before saving the mock's story as "complete".