### PR TITLE
[Feat] Adds Unmock User Agent to headers

### DIFF
--- a/unmock/core/http.py
+++ b/unmock/core/http.py
@@ -3,6 +3,7 @@ from .utils import Patchers, parse_url, is_python_version_at_least
 from six.moves import http_client
 from . import PATCHERS, STORIES
 from .options import UnmockOptions
+from .utils import unmock_user_agent
 
 __all__ = ["initialize", "reset"]
 
@@ -63,6 +64,8 @@ def initialize(unmock_options):
             if token is not None:  # Add token to official headers
                 # Added as a 1-tuple as the actual call to `putheader` (later on) unpacks it
                 req.unmock_data["headers"]["Authorization"] = ("Bearer {token}".format(token=token), )
+            ua_key, ua_value = unmock_user_agent()
+            req.unmock_data["headers"][ua_key] = ua_value
             setattr(conn, "unmock", req)
 
 

--- a/unmock/core/http.py
+++ b/unmock/core/http.py
@@ -65,7 +65,7 @@ def initialize(unmock_options):
                 # Added as a 1-tuple as the actual call to `putheader` (later on) unpacks it
                 req.unmock_data["headers"]["Authorization"] = ("Bearer {token}".format(token=token), )
             ua_key, ua_value = unmock_user_agent()
-            req.unmock_data["headers"][ua_key] = ua_value
+            req.unmock_data["headers"][ua_key] = (ua_value, )
             setattr(conn, "unmock", req)
 
 

--- a/unmock/core/utils.py
+++ b/unmock/core/utils.py
@@ -14,11 +14,11 @@ __all__ = ["Patchers", "parse_url", "is_python_version_at_least", "makedirs", "u
 def unmock_user_agent():
     """Returns an unmock user agent header and value"""
     svi = sys.version_info
-    return "X-Unmock-Client-User-Agent", {
+    return "X-Unmock-Client-User-Agent", json.dumps({
         "lang": "python",
         "lang_version": "{major}.{minor}.{patch}".format(major=svi.major, minor=svi.minor, patch=svi.micro),
         "unmock_version": __version__
-    }
+    })
 
 def is_python_version_at_least(version):
     """

--- a/unmock/core/utils.py
+++ b/unmock/core/utils.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     import mock
 
-from ...__version__ import __version__
+from ..__version__ import __version__
 
 __all__ = ["Patchers", "parse_url", "is_python_version_at_least", "makedirs", "unmock_user_agent"]
 

--- a/unmock/core/utils.py
+++ b/unmock/core/utils.py
@@ -7,7 +7,17 @@ try:
 except ImportError:
     import mock
 
+from ...__version__ import __version__
+
 __all__ = ["Patchers", "parse_url", "is_python_version_at_least", "makedirs"]
+
+def unmock_user_agent():
+    svi = sys.version_info
+    return {
+        "lang": "python",
+        "lang_version": "{major}.{minor}.{patch}".format(major=svi.major, minor=svi.minor, patch=svi.micro),
+        "unmock_version": __version__
+    }
 
 def is_python_version_at_least(version):
     """

--- a/unmock/core/utils.py
+++ b/unmock/core/utils.py
@@ -9,11 +9,12 @@ except ImportError:
 
 from ...__version__ import __version__
 
-__all__ = ["Patchers", "parse_url", "is_python_version_at_least", "makedirs"]
+__all__ = ["Patchers", "parse_url", "is_python_version_at_least", "makedirs", "unmock_user_agent"]
 
 def unmock_user_agent():
+    """Returns an unmock user agent header and value"""
     svi = sys.version_info
-    return {
+    return "X-Unmock-Client-User-Agent", {
         "lang": "python",
         "lang_version": "{major}.{minor}.{patch}".format(major=svi.major, minor=svi.minor, patch=svi.micro),
         "unmock_version": __version__


### PR DESCRIPTION
With the same idea as is for [`unmock-js`](https://github.com/unmock/unmock-js/pull/5).