### PR TITLE
[Feat] Look for credentials in home directory and cwd

### DIFF
--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -50,11 +50,13 @@ def initialize(**kwargs):
         intercepting the calls. Defaults to ["127.0.0.1", "127.0.0.0", "localhost"]
     :type string, list of strings
     """
-
+    import os
     from . import core  # Imported internally to keep the namespace clear
     new_stories = kwargs.get("story")
     if new_stories is not None:
         core.STORIES += new_stories if isinstance(new_stories, list) else [new_stories]
+    # By default, create the .unmock folder under cwd
+    kwargs["storage_path"] = kwargs.get("storage_path", os.getcwd())
     unmock_options = UnmockOptions(**kwargs)
 
     core.http.initialize(unmock_options)

--- a/unmock/core/persistence.py
+++ b/unmock/core/persistence.py
@@ -198,6 +198,8 @@ class FSPersistence(Persistence):
     def load_token(self):
         if self.token is not None:
             return self.token
+        # We check in both the given config_path (default is under cwd) and under user home path.
+        # At worse, we check twice if the credentials file exists under the user's homepath.
         for config_file in [self.config_path, os.path.join(FSPersistence.HOMEPATH, FSPersistence.CREDENTIALS_FILE)]:
             if os.path.exists(config_file):
                 iniparser = configparser.ConfigParser(defaults={"token": None}, allow_no_value=True)

--- a/unmock/core/persistence.py
+++ b/unmock/core/persistence.py
@@ -198,10 +198,7 @@ class FSPersistence(Persistence):
     def load_token(self):
         if self.token is not None:
             return self.token
-        locations = [self.config_path]  # Create list of possible locations for credentials file, first is given path
-        if FSPersistence.HOMEPATH != self.homepath:  # If the user home path is not the given one, then look there too.
-            locations.append(os.path.join(FSPersistence.HOMEPATH, FSPersistence.CREDENTIALS_FILE))
-        for config_file in locations:
+        for config_file in [self.config_path, os.path.join(FSPersistence.HOMEPATH, FSPersistence.CREDENTIALS_FILE)]:
             if os.path.exists(config_file):
                 iniparser = configparser.ConfigParser(defaults={"token": None}, allow_no_value=True)
                 iniparser.read(config_file)

--- a/unmock/core/persistence.py
+++ b/unmock/core/persistence.py
@@ -92,10 +92,12 @@ class FSPersistence(Persistence):
     """File system based persistence layer"""
     HEADERS_FILE = "response-header.json"
     BODY_FILE = "response.json"
+    HOMEPATH = os.path.expanduser("~")
+    CREDENTIALS_FILE = "credentials"
 
     def __init__(self, token, path=None):
         super(FSPersistence, self).__init__(token)
-        self.homepath = os.path.abspath(path or os.path.expanduser("~"))  # Given directory or home path
+        self.homepath = os.path.abspath(path or FSPersistence.HOMEPATH)  # Given directory or home path
         makedirs(self.unmock_dir)  # Create home directory if needed
         # Maps unmock hashes (string) to partial json body (string), when body is read in chunks
         self.partial_body_jsons = dict()
@@ -110,7 +112,7 @@ class FSPersistence(Persistence):
 
     @property
     def config_path(self):
-        return os.path.join(self.unmock_dir, "credentials")
+        return os.path.join(self.unmock_dir, FSPersistence.CREDENTIALS_FILE)
 
     @property
     def hash_dir(self):
@@ -196,7 +198,11 @@ class FSPersistence(Persistence):
     def load_token(self):
         if self.token is not None:
             return self.token
-        if os.path.exists(self.config_path):
-            iniparser = configparser.ConfigParser(defaults={"token": None}, allow_no_value=True)
-            iniparser.read(self.config_path)
-            return iniparser.get("unmock", "token")
+        locations = [self.config_path]  # Create list of possible locations for credentials file, first is given path
+        if FSPersistence.HOMEPATH != self.homepath:  # If the user home path is not the given one, then look there too.
+            locations.append(os.path.join(FSPersistence.HOMEPATH, FSPersistence.CREDENTIALS_FILE))
+        for config_file in locations:
+            if os.path.exists(config_file):
+                iniparser = configparser.ConfigParser(defaults={"token": None}, allow_no_value=True)
+                iniparser.read(config_file)
+                return iniparser.get("unmock", "token")


### PR DESCRIPTION
To match [UN-30], we'd like to first look for the `credentials` fileunder the current working directory's `.unmock` folder, and if not found - look at the user's home directory's `.unmock` folder.

[UN-30]: https://meeshkan.atlassian.net/browse/UN-30