### PR TITLE
[Feat] Context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,16 +89,21 @@ pytest tests --unmock
 ```
 
 2. You can control use unmock in a scoped manner using context managers:
-```python
+```
 # do stuff
-with unmock.Scope():
+with unmock.patch():
     response = requests.get("https://www.example.com/")
 # do stuff with mocked response
-real_response = requests.get("https://www.example.com/")  # won't be mocked    
+real_response = requests.get("https://www.example.com/")  # won't be mocked
+
+# You can also access the returned object to modify certain runtime behaviour:
+with unmock.patch() as opts:
+    # can modify certain behaviour aspects via `opts` object now too
+    response = requests.get("https://www.example.com/")
 ``` 
 
 3. You can have fine grained control over unmock using the `init` and
-`reset` methods, and handling the `UnmockOptions` object during runtime:
+`reset` methods, and modify the `UnmockOptions` object during runtime:
 ```python
 import unmock
 
@@ -148,8 +153,8 @@ consult the documentation about that service
 
 ### Scoping
 As a handy shortcut to initializing and reseting the capturing of API
-calls, we also offer the use of context manager via `unmock.Scope()`.
-`Scope` accepts as parameters anything that `init` accepts.
+calls, we also offer the use of context manager via `unmock.patch()`.
+`patch` accepts as parameters anything that `init` accepts.
 
 ### Saving mocks
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,6 @@ def test_init_and_reset():
 
 def test_context_manager():
     assert_number_of_patches(0)
-    with unmock.Scope():
+    with unmock.patch():
         assert_number_of_patches(5)
     assert_number_of_patches(0)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,13 +1,25 @@
 import unmock
 import unmock.core as unmock_core
 
+def assert_number_of_patches(expected_number):
+    assert len(unmock_core.PATCHERS.targets) == len(unmock_core.PATCHERS.patchers) == expected_number
+
 def test_init_and_reset():
     unmock.init()
-    assert len(unmock_core.PATCHERS.targets) == len(unmock_core.PATCHERS.patchers) == 4
+    assert_number_of_patches(4)  # Four different function for HTTPRequest
     unmock.reset()
-    assert len(unmock_core.PATCHERS.targets) == len(unmock_core.PATCHERS.patchers) == 0
+    assert_number_of_patches(0)
 
     unmock.init(save=True)
-    assert len(unmock_core.PATCHERS.targets) == len(unmock_core.PATCHERS.patchers) == 5
+    assert_number_of_patches(5)  # Plus one for HTTPResponse
     unmock.reset()
-    assert len(unmock_core.PATCHERS.targets) == len(unmock_core.PATCHERS.patchers) == 0
+    assert_number_of_patches(0)
+
+def test_context_manager():
+    assert_number_of_patches(0)
+    with unmock.Scope():
+        assert_number_of_patches(4)
+    assert_number_of_patches(0)
+    with unmock.Scope(save=True):
+        assert_number_of_patches(5)
+    assert_number_of_patches(0)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,20 +6,12 @@ def assert_number_of_patches(expected_number):
 
 def test_init_and_reset():
     unmock.init()
-    assert_number_of_patches(4)  # Four different function for HTTPRequest
-    unmock.reset()
-    assert_number_of_patches(0)
-
-    unmock.init(save=True)
-    assert_number_of_patches(5)  # Plus one for HTTPResponse
+    assert_number_of_patches(5)  # Four different mocks for HTTPRequest plus one for HTTPResponse
     unmock.reset()
     assert_number_of_patches(0)
 
 def test_context_manager():
     assert_number_of_patches(0)
     with unmock.Scope():
-        assert_number_of_patches(4)
-    assert_number_of_patches(0)
-    with unmock.Scope(save=True):
         assert_number_of_patches(5)
     assert_number_of_patches(0)

--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -26,7 +26,7 @@ def test_context_manager():
     assert response.status_code == 200
     with pytest.raises(Exception):
         response.json()  # Expected to raise as no valid JSON response
-    with unmock.Scope():
+    with unmock.patch():
         response = requests.get("http://www.example.com/", timeout=TIMEOUT)  # Nothing here anyway
         assert response.status_code == 200
         assert response.json()  # Expected to pass as valid response from unmock service is JSON file

--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -1,11 +1,12 @@
 import requests
+from six import text_type
 
 try:
     from unittest import mock
 except ImportError:
     import mock
 
-from .utils import get_logger, is_text
+from .utils import get_logger
 
 # Tests that actually send through to the unmock service and make sure it's all formed correctly
 TIMEOUT = 10
@@ -40,7 +41,7 @@ def test_behance(unmock_and_reset):
     response = requests.get("{url}/{id}/comments{api}".format(url=URL, id=projects[0]["id"], api=API), timeout=TIMEOUT)
     comments = response.json().get("comments")
     assert comments, "Expecting a non-empty list of 'comments' in response"
-    assert is_text(comments[0]["comment"]), "Comments should be text"
+    assert isinstance(comments[0]["comment"], text_type), "Comments should be text"
 
 
 def test_hubapi(unmock_and_reset):

--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -1,3 +1,4 @@
+import pytest
 import requests
 from six import text_type
 
@@ -17,6 +18,18 @@ def test_no_credentials_no_signature(unmock_and_reset):
     unmock_and_reset(refresh_token=None)
     response = requests.get("http://www.example.com/", timeout=TIMEOUT)  # Nothing here anyway
     assert response.json()
+
+
+def test_context_manager():
+    import unmock
+    response = requests.get("http://www.example.com/", timeout=TIMEOUT)  # Nothing here anyway
+    assert response.status_code == 200
+    with pytest.raises(Exception):
+        response.json()  # Expected to raise as no valid JSON response
+    with unmock.Scope():
+        response = requests.get("http://www.example.com/", timeout=TIMEOUT)  # Nothing here anyway
+        assert response.status_code == 200
+        assert response.json()  # Expected to pass as valid response from unmock service is JSON file
 
 
 def test_no_credentials_with_signature(unmock_and_reset):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,14 +18,6 @@ def get_logger():
     return LOGGER
 
 
-def is_text(text):
-    """Checks whether text is string/unicode (Python 2/3 compatibility)"""
-    try:
-        return isinstance(text, (unicode, str))
-    except NameError:
-        return isinstance(text, str)
-
-
 def one_hit_server():
     def init_server():
         srv = BaseHTTPServer.HTTPServer(("127.0.0.1", 7331), RequestHandler)

--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -78,3 +78,12 @@ def is_mocking():
     """
     from . import core
     return len(core.PATCHERS.targets) > 0
+
+
+class Scope:
+    """Uses unmock locally as context manager"""
+    def __enter__(self, **kwargs):
+        return initialize(**kwargs)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        reset()

--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -81,7 +81,9 @@ def is_mocking():
 
 
 class Scope:
-    """Uses unmock locally as context manager"""
+    """
+    Allows the usage of unmock with scope-specific context managers.
+    """
     def __init__(self, **kwargs):
         self.kwargs = kwargs
 

--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -82,8 +82,11 @@ def is_mocking():
 
 class Scope:
     """Uses unmock locally as context manager"""
-    def __enter__(self, **kwargs):
-        return initialize(**kwargs)
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def __enter__(self):
+        return initialize(**self.kwargs)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         reset()

--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -80,7 +80,7 @@ def is_mocking():
     return len(core.PATCHERS.targets) > 0
 
 
-class Scope:
+class patch:
     """
     Allows the usage of unmock with scope-specific context managers.
     """

--- a/unmock/core/http.py
+++ b/unmock/core/http.py
@@ -209,9 +209,7 @@ def initialize(unmock_options):
     original_putheader = PATCHERS.patch("six.moves.http_client.HTTPConnection.putheader", unmock_putheader)
     original_endheaders = PATCHERS.patch("six.moves.http_client.HTTPConnection.endheaders", unmock_end_headers)
     original_getresponse = PATCHERS.patch("six.moves.http_client.HTTPConnection.getresponse", unmock_get_response)
-    if unmock_options.save:
-        # Only patch this if we have save=True or save is a list of hashes/stories to save
-        original_response_read = PATCHERS.patch("six.moves.http_client.HTTPResponse.read", unmock_response_read)
+    original_response_read = PATCHERS.patch("six.moves.http_client.HTTPResponse.read", unmock_response_read)
 
     PATCHERS.start()
 


### PR DESCRIPTION
Addresses #21 and [UN-14].
- Add a `Scope` to use unmock for even more specific scopes with the use of context managers:
```python
# do stuff
with unmock.Scope():
    res = requests.get(some_url)
# do stuff
```
- The call / initialization takes `kwargs` that are passed on to `init` so one can use e.g. `with unmock.Scope(save=True, refresh_token=my_awesome_token)`, etc.
- Adds matching tests

[UN-14]: https://meeshkan.atlassian.net/browse/UN-14