### PR TITLE
[Fix] Uploading to PyPi when merging with dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,12 +102,25 @@ jobs:
     - setup
     - test
 
+  test-deploy:
+    docker:
+      - image: circleci/python:3.6.8
+    steps:
+    - setup
+    - add_ssh_keys:
+        fingerprints:
+          - "2f:9a:8b:13:75:82:e8:62:be:be:e4:d3:10:fa:09:fe"
+    - run: git config credential.helper "/bin/bash ./.circleci/git-credentials-helper.sh"
+    - run: sudo python setup.py testupload
+
   deploy:
     docker:
       - image: circleci/python:3.6.8
     steps:
     - setup
-    - add_ssh_keys
+    - add_ssh_keys:
+        fingerprints:
+          - "2f:9a:8b:13:75:82:e8:62:be:be:e4:d3:10:fa:09:fe"
     - run: git config credential.helper "/bin/bash ./.circleci/git-credentials-helper.sh"
     - run: sudo python setup.py upload
 
@@ -122,6 +135,18 @@ workflows:
       - linux35
       - linux36
       - linux37
+      - test-deploy:
+          requires:
+            #- macOS36
+            #- macOS37
+            - linux27
+            - linux34
+            - linux35
+            - linux36
+            - linux37
+          filters:
+            branches:
+              ignore: master
       - deploy:
           requires:
             #- macOS36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ commands:
             - store_artifacts:
                 path: htmlcov
             - codecov/upload
+
   build-task:
     description: "Builds the python wheel"
     steps:
@@ -61,13 +62,6 @@ commands:
       - run:
           name: "Pushes git tag"
           command: python setup.py tags
-
-  test-deploy-task:
-    description: "Dry-run; uploads the Python wheel to TestPyPi"
-    steps:
-      - run:
-          name: "Upload to TestPyPi"
-          command: twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
 jobs:
   # Find tags here: https://circleci.com/docs/2.0/docker-image-tags.json
@@ -126,18 +120,6 @@ jobs:
     - setup
     - test
 
-  test-deploy:
-    docker:
-      - image: circleci/python:3.6.8
-    steps:
-    - setup
-    - add_ssh_keys:
-        fingerprints:
-          - "2f:9a:8b:13:75:82:e8:62:be:be:e4:d3:10:fa:09:fe"
-    - run: git config credential.helper "/bin/bash ./.circleci/git-credentials-helper.sh"
-    - build-task
-    - test-deploy-task
-
   deploy:
     docker:
       - image: circleci/python:3.6.8
@@ -161,18 +143,6 @@ workflows:
       - linux35
       - linux36
       - linux37
-      - test-deploy:
-          requires:
-            #- macOS36
-            #- macOS37
-            - linux27
-            - linux34
-            - linux35
-            - linux36
-            - linux37
-          filters:
-            branches:
-              ignore: master
       - deploy:
           requires:
             #- macOS36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ commands:
       - run:
           name: Installing package
           command: sudo pip install --upgrade -e .[dev]
+
   test:
     description: "Run tests, possibly publishing results"
     parameters:
@@ -44,6 +45,29 @@ commands:
             - store_artifacts:
                 path: htmlcov
             - codecov/upload
+  build-task:
+    description: "Builds the python wheel"
+    steps:
+      - run:
+          name: "Builds wheel"
+          command: sudo python setup.py sdist bdist_wheel --universal
+
+  deploy-task:
+    description: "Uploads the wheel to PyPi and pushes git tags"
+    steps:
+      - run:
+          name: "Uploads to PyPi"
+          command: twine upload dist/*
+      - run:
+          name: "Pushes git tag"
+          command: python setup.py tags
+
+  test-deploy-task:
+    description: "Dry-run; uploads the Python wheel to TestPyPi"
+    steps:
+      - run:
+          name: "Upload to TestPyPi"
+          command: twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
 jobs:
   # Find tags here: https://circleci.com/docs/2.0/docker-image-tags.json
@@ -111,7 +135,8 @@ jobs:
         fingerprints:
           - "2f:9a:8b:13:75:82:e8:62:be:be:e4:d3:10:fa:09:fe"
     - run: git config credential.helper "/bin/bash ./.circleci/git-credentials-helper.sh"
-    - run: sudo python setup.py testupload
+    - build-task
+    - test-deploy-task
 
   deploy:
     docker:
@@ -122,7 +147,8 @@ jobs:
         fingerprints:
           - "2f:9a:8b:13:75:82:e8:62:be:be:e4:d3:10:fa:09:fe"
     - run: git config credential.helper "/bin/bash ./.circleci/git-credentials-helper.sh"
-    - run: sudo python setup.py upload
+    - build-task
+    - deploy-task
 
 workflows:
   version: 2

--- a/setup.py
+++ b/setup.py
@@ -63,48 +63,6 @@ class SetupCommand(Command):
         print('\n\033[1m{0}\033[0m'.format(s))
 
 
-class BuildDistCommand(SetupCommand):
-    """Support setup.py build."""
-    description = "Build the package."
-
-    def run(self):
-        try:
-            self.status("Removing previous builds...")
-            rmtree(os.path.join(here, 'dist'))
-        except OSError:
-            pass
-
-        self.status("Building Source and Wheel (universal) distribution...")
-        os.system("{executable} setup.py sdist bdist_wheel --universal".format(executable=sys.executable))
-        sys.exit()
-
-
-class UploadCommand(SetupCommand):
-    """Support setup.py upload."""
-    description = "Build and publish the package."
-
-    def run(self):
-        try:
-            self.status("Removing previous builds...")
-            rmtree(os.path.join(here, 'dist'))
-        except OSError:
-            pass
-
-        self.status("Building Source and Wheel (universal) distribution...")
-        os.system("{executable} setup.py sdist bdist_wheel --universal".format(executable=sys.executable))
-
-        self.status("Uploading the package to PyPI via Twine...")
-        ret = os.system("twine upload dist/*")
-
-        if ret != 0:
-            sys.exit(ret)
-        self.status("Pushing git tags...")
-        os.system("git tag v{about}".format(about=about['__version__']))
-        os.system("git push --tags")
-
-        sys.exit()
-
-
 class PushGitTagCommand(SetupCommand):
     """Supports setup.py tags"""
     description = "Pushes a git tag"
@@ -115,38 +73,6 @@ class PushGitTagCommand(SetupCommand):
         os.system("git push --tags")
 
         sys.exit()
-
-
-class TestUploadCommand(SetupCommand):
-    """Supports setup.py testupload"""
-    description = "Publishes the package to TestPyPi without pushing tags to git"
-
-    def run(self):
-        try:
-            self.status("Removing previous builds...")
-            rmtree(os.path.join(here, 'dist'))
-        except OSError:
-            pass
-
-        self.status("Building Source and Wheel (universal) distribution...")
-        os.system("{executable} setup.py sdist bdist_wheel --universal".format(executable=sys.executable))
-
-        self.status("[Test] Uploading the package to TestPyPI via Twine...")
-        self.status("[Environment Variables] Username: {0}".format(os.environ.get("TWINE_USERNAME")))
-        self.status("[Environment Variables] Password: {0}".format(os.environ.get("TWINE_PASSWORD")))
-        ret = os.system("twine upload --repository-url https://test.pypi.org/legacy/ dist/*")
-
-        sys.exit(ret)
-
-
-class TestCommand(SetupCommand):
-    """Support setup.py test."""
-    description = "Run local test if they exist"
-
-    def run(self):
-        os.system("pytest")
-        sys.exit()
-
 
 setup(
     name=NAME,
@@ -179,6 +105,5 @@ setup(
         'Topic :: Software Development :: Testing :: Mocking'
     ],
     entry_points = {'pytest11': ['unmock = unmock.pytest.plugin']},
-    cmdclass={'dist': BuildDistCommand, 'upload': UploadCommand, 'test': TestCommand, 'testupload': TestUploadCommand,
-              'tags': PushGitTagCommand}
+    cmdclass={'tags': PushGitTagCommand}
 )

--- a/setup.py
+++ b/setup.py
@@ -94,13 +94,28 @@ class UploadCommand(SetupCommand):
         os.system("{executable} setup.py sdist bdist_wheel --universal".format(executable=sys.executable))
 
         self.status("Uploading the package to PyPI via Twine...")
-        os.system("twine upload dist/*")
+        ret = os.system("twine upload dist/*")
 
+        if ret != 0:
+            sys.exit(ret)
         self.status("Pushing git tags...")
         os.system("git tag v{about}".format(about=about['__version__']))
         os.system("git push --tags")
 
         sys.exit()
+
+
+class PushGitTagCommand(SetupCommand):
+    """Supports setup.py tags"""
+    description = "Pushes a git tag"
+
+    def run(self):
+        self.status("Pushing git tags...")
+        os.system("git tag v{about}".format(about=about['__version__']))
+        os.system("git push --tags")
+
+        sys.exit()
+
 
 class TestUploadCommand(SetupCommand):
     """Supports setup.py testupload"""
@@ -119,9 +134,9 @@ class TestUploadCommand(SetupCommand):
         self.status("[Test] Uploading the package to TestPyPI via Twine...")
         self.status("[Environment Variables] Username: {0}".format(os.environ.get("TWINE_USERNAME")))
         self.status("[Environment Variables] Password: {0}".format(os.environ.get("TWINE_PASSWORD")))
-        os.system("twine upload --repository-url https://test.pypi.org/legacy/ dist/*")
+        ret = os.system("twine upload --repository-url https://test.pypi.org/legacy/ dist/*")
 
-        sys.exit()
+        sys.exit(ret)
 
 
 class TestCommand(SetupCommand):
@@ -164,5 +179,6 @@ setup(
         'Topic :: Software Development :: Testing :: Mocking'
     ],
     entry_points = {'pytest11': ['unmock = unmock.pytest.plugin']},
-    cmdclass={'dist': BuildDistCommand, 'upload': UploadCommand, 'test': TestCommand, 'testupload': TestUploadCommand}
+    cmdclass={'dist': BuildDistCommand, 'upload': UploadCommand, 'test': TestCommand, 'testupload': TestUploadCommand,
+              'tags': PushGitTagCommand}
 )

--- a/setup.py
+++ b/setup.py
@@ -60,11 +60,11 @@ class SetupCommand(Command):
     @staticmethod
     def status(s):
         """Prints things in bold."""
-        print('\033[1m{0}\033[0m'.format(s))
+        print('\n\033[1m{0}\033[0m'.format(s))
 
 
 class BuildDistCommand(SetupCommand):
-    """Support setup.py upload."""
+    """Support setup.py build."""
     description = "Build the package."
 
     def run(self):
@@ -99,6 +99,27 @@ class UploadCommand(SetupCommand):
         self.status("Pushing git tags...")
         os.system("git tag v{about}".format(about=about['__version__']))
         os.system("git push --tags")
+
+        sys.exit()
+
+class TestUploadCommand(SetupCommand):
+    """Supports setup.py testupload"""
+    description = "Publishes the package to TestPyPi without pushing tags to git"
+
+    def run(self):
+        try:
+            self.status("Removing previous builds...")
+            rmtree(os.path.join(here, 'dist'))
+        except OSError:
+            pass
+
+        self.status("Building Source and Wheel (universal) distribution...")
+        os.system("{executable} setup.py sdist bdist_wheel --universal".format(executable=sys.executable))
+
+        self.status("[Test] Uploading the package to TestPyPI via Twine...")
+        self.status("[Environment Variables] Username: {0}".format(os.environ.get("TWINE_USERNAME")))
+        self.status("[Environment Variables] Password: {0}".format(os.environ.get("TWINE_PASSWORD")))
+        os.system("twine upload --repository-url https://test.pypi.org/legacy/ dist/*")
 
         sys.exit()
 
@@ -143,5 +164,5 @@ setup(
         'Topic :: Software Development :: Testing :: Mocking'
     ],
     entry_points = {'pytest11': ['unmock = unmock.pytest.plugin']},
-    cmdclass={'dist': BuildDistCommand, 'upload': UploadCommand, 'test': TestCommand}
+    cmdclass={'dist': BuildDistCommand, 'upload': UploadCommand, 'test': TestCommand, 'testupload': TestUploadCommand}
 )


### PR DESCRIPTION
Title is self explanatory.
- Adds the various commands for uploading to PyPi in CircleCI config.
- Removes the matching commands from `setup.py` (cleanup).
- `setup.py` effectively has only one custom command now - `tags` to push tags to git.