### PR TITLE
Basic new MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # [Unmock](https://www.unmock.io/) (Python SDK)
-[![CircleCI](https://circleci.com/gh/unmock/unmock-python.svg?style=shield)](https://circleci.com/gh/unmock/unmock-python) 
+
+[![CircleCI](https://circleci.com/gh/unmock/unmock-python.svg?style=shield)](https://circleci.com/gh/unmock/unmock-python)
 [![codecov](https://codecov.io/gh/unmock/unmock-python/branch/dev/graph/badge.svg)](https://codecov.io/gh/unmock/unmock-python)
 [![PyPI version](https://badge.fury.io/py/unmock.svg)](https://badge.fury.io/py/unmock)
 
@@ -33,12 +34,6 @@ We're open to more requests - just [let us know](mailto:contact@unmock.io)!
     - [Tests](#tests)
     - [Development](#development)
     - [unmock.io](#unmockio)
-    - [Scoping](#scoping)
-    - [Saving mocks](#saving-mocks)
-    - [Ignoring aspects of a mock](#ignoring-aspects-of-a-mock)
-    - [Adding a signature](#adding-a-signature)
-    - [Whitelisting API](#whitelisting-api)
-    - [unmock.io tokens](#unmockio-tokens)
   - [Contributing](#contributing)
   - [License](#license)
 
@@ -56,7 +51,7 @@ yet, or to tweak return values from the unmock service, you can consult
 the URLs printed to the command line by unmock.
 
 We intend to offer Python2.7 support quite soon, along with other common
-libraries such as `aiohttp`, `pycurl`, etc.  
+libraries such as `aiohttp`, `pycurl`, etc.
 
 ## Install
 
@@ -71,7 +66,7 @@ $ pip install unmock
 In your unit tests, you can invoke unmock in several ways:
 
 1. If you're using pytest for your tests, you can either use the unmock
-fixture (you don't even need to import unmock!) -
+   fixture (you don't even need to import unmock!) -
 
 ```python
 import pytest
@@ -84,11 +79,13 @@ def test_behance(unmock_local):
 
 ... or you may want to use unmock for all your tests, in which case you
 can simply use the `--unmock` flag for pytest:
+
 ```bash
 pytest tests --unmock
 ```
 
 2. You can control use unmock in a scoped manner using context managers:
+
 ```
 # do stuff
 with unmock.patch():
@@ -100,10 +97,11 @@ real_response = requests.get("https://www.example.com/")  # won't be mocked
 with unmock.patch() as opts:
     # can modify certain behaviour aspects via `opts` object now too
     response = requests.get("https://www.example.com/")
-``` 
+```
 
 3. You can have fine grained control over unmock using the `init` and
-`reset` methods, and modify the `UnmockOptions` object during runtime:
+   `reset` methods, and modify the `UnmockOptions` object during runtime:
+
 ```python
 import unmock
 
@@ -116,7 +114,6 @@ unmock.reset()
 res3 = requests.get("https://www.example.com")  # will not be mocked
 ```
 
-
 Unmock will then either serve JIT semantically functionally correct
 mocks from its database or an empty JSON object for unmocked APIs that
 can be filled in by the user. The address of these editable objects is
@@ -124,133 +121,11 @@ printed to the command line during tests.
 
 ### Development
 
-After you create your flask, django, or own server, call
-
-
-```python
-unmock_options = unmock.init()
-unmock_options.ignore("story")
-
-# equivalent to calling:
-unmock.init(ignore="story")
-```
-
-This has the same effect as activating unmock in your tests.
-It will intercept HTTP traffic and serve semantically and functionally
-adequate mocks of the APIs in the unmock catalogue.
-The main difference is the result of `ignore("story")` passed to unmock
-options, which tells the service to ignore the order of mocked requests.
-Always use this option when the order of mocked data does not matter,
-i.e. when you are in sandbox or development mode.
-For users of the [unmock.io](https://www.unmock.io) service, this will
-help unmock better organize your mocks in its web dashboard.
-
 ### unmock.io
 
 The URLs printed to the command line are hosted by unmock.io. You can
 consult the documentation about that service
 [here](https://www.unmock.io/docs).
-
-### Scoping
-As a handy shortcut to initializing and reseting the capturing of API
-calls, we also offer the use of context manager via `unmock.patch()`.
-`patch` accepts as parameters anything that `init` accepts.
-
-### Saving mocks
-
-All mocks can be saved to a folder called `.unmock` in your user's home
-directory by adding a `save` field to the unmock options object like so:
-
-```python
-unmock_options = unmock.init(save=True)
-```
-You can also specify a specific location to save the directory:
-```python
-unmock_options = unmock.init(save=True, path=".")  # Saves in current path
-```
-Unmock refers to every mock by a unique hash. Individual mocks or groups
-of mocks can be saved by setting save to either a single hash or an
-array of hashes like so:
-
-```python
-unmock_options = unmock.init(save=["ahash", "anotherhash", "yetanotherhash"])
-```
-
-### Ignoring aspects of a mock
-
-Sometimes, you would like for two mocks of slightly API calls to be
-treated as equivalent by unmock. For example, you may want all `GET`
-calls to the same path with different headers to be served the same
-mock. To do this, use the `ignore` field of the unmock options object.
-You can do this while initializing unmock or afterwards (as shown before
-with ignoring `"story"`):
-
-```python
-# Option A:
-unmock_options = unmock.init()
-unmock_options.ignore("headers", "story")
-# Option B:
-unmock.init(ignore=["headers", "story"])
-```
-
-The following fields may be ignored:
-
-* `headers`: the headers of the request
-* `hostname`: the hostname of the request
-* `method`: the method of the request (ie GET, POST, PUT, DELETE).
-Note that this is *case insensitive*!
-* `path`: the path of the request
-* `story`: the story of the request, meaning its order in a series of requests
-
-Ignore evaluates regular expressions, so you can also pass
-`"headers|path"` instead of `["headers", "path"]`. Furthermore, to
-ignore nested headers, pass a dictionary such as
-`{"headers": "Authorization" }`, or to match against the value of a
-header, `{"headers": { Authorization: "Bearer *" }}`. When using the
-ignore _method_ on the `UnmockOptions` object (returned from a call to `init`),
-you may pass either a list (`*args`) or a dictionary (`**kwargs`).
-
-### Adding a signature
-
-Sometimes, it is useful to sign a mock with a unique signature. This is
-useful, for example, when AB testing code that should serve two
-different mocks for the same endpoint in otherwise similar conditions.
-To do this, use the `signature` field of the unmock options object:
-
-```python
-unmock_options = unmock.init()
-unmock_options.signature = "signature-for-this-particular-test"
-# Equivalent to
-unmock.init(signature="signature-for-this-particular-test")
-```
-
-### Whitelisting API
-
-If you do not want a particular API to be mocked, whitelist it.
-
-```python
-unmock_options = unmock.init()
-unmock_options.whitelist = ["api.hubspot.com", "api.typeform.com"]
-# Equivalent to:
-unmock.init(whitelist=["api.hubspot.com", "api.typeform.com"])
-```
-
-### unmock.io tokens
-
-If you are subscribed to the [unmock.io](https://www.unmock.io) service,
-you can pass your unmock token directly to the unmock object.
-
-```
-unmock.init(token="my-token")
-```
-
-At a certain point this becomes a bit tedious, (even if very readable),
-at which point you will want to create a credentials file. See
-[unmock.io/docs](https://www.unmock.io/docs) for more information on
-credential files.
-Behind the scenes, we automatically create a credentials file for you,
-for caching purposes. With this, subsequent calls to `unmock.init()`
-will read the token from the credential files. 
 
 ## Contributing
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,23 +1,10 @@
-import tempfile
-import shutil
 import pytest
 import unmock
-from .utils import get_logger, get_token
-
-
-@pytest.fixture
-def tmpdir():
-  tmpd = tempfile.mkdtemp()
-  yield tmpd
-  shutil.rmtree(tmpd)
-  return
 
 
 @pytest.fixture
 def unmock_and_reset():
   def init(**kwargs):
-    default_kwargs = {"refresh_token": get_token(), "logger": get_logger()}
-    default_kwargs.update(kwargs)
-    return unmock.init(**default_kwargs)
+    unmock.on(**default_kwargs)
   yield init
-  unmock.reset()
+  unmock.off()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,17 +1,21 @@
 import unmock
 import unmock.core as unmock_core
 
+
 def assert_number_of_patches(expected_number):
-    assert len(unmock_core.PATCHERS.targets) == len(unmock_core.PATCHERS.patchers) == expected_number
+  assert len(unmock_core.PATCHERS.targets) == len(
+      unmock_core.PATCHERS.patchers) == expected_number
+
 
 def test_init_and_reset():
-    unmock.init()
-    assert_number_of_patches(5)  # Four different mocks for HTTPRequest plus one for HTTPResponse
-    unmock.reset()
-    assert_number_of_patches(0)
+  unmock.init()
+  assert_number_of_patches(3)  # Three different mocks for HTTPRequest
+  unmock.off()
+  assert_number_of_patches(0)
+
 
 def test_context_manager():
-    assert_number_of_patches(0)
-    with unmock.patch():
-        assert_number_of_patches(5)
-    assert_number_of_patches(0)
+  assert_number_of_patches(0)
+  with unmock.patch():
+    assert_number_of_patches(3)
+  assert_number_of_patches(0)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,14 @@
+import unmock
+import requests
+
+
+def replyFn(request):
+  print(request.__dict__)
+  return {"content": "Hello World!", "status": 204, "headers": {"foo?": "bar!"}}
+
+
+def test_reply_fn():
+  unmock.on(replyFn=replyFn)
+  res = requests.get("https://www.example.com")
+  assert res.text == "Hello World!"
+  unmock.off()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,10 @@ import multiprocessing
 from six.moves import BaseHTTPServer
 
 
+def empty_reply(_):
+  return {}
+
+
 def one_hit_server():
   def init_server():
     srv = BaseHTTPServer.HTTPServer(("127.0.0.1", 7331), RequestHandler)

--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -1,26 +1,23 @@
 from .__version__ import __version__  # Conform to PEP-0396
 
 from . import pytest
-from .core import UnmockOptions, exceptions
+from .core import UnmockOptions, Request
+
+
+def on(**kwargs):
+  """Shorthand for initialize"""
+  initialize(**kwargs)
 
 
 def init(**kwargs):
   """Shorthand for initialize"""
-  return initialize(**kwargs)
+  initialize(**kwargs)
 
 
 def initialize(**kwargs):
   """
   Initialize the unmock library for capturing API calls.
   Pass keyword arguments to be used for internal options:
-
-  :param save: whether or not to save all mocks (when using boolean value), or a list of specific story IDs to
-      save. Deafult to False.
-  :type save boolean, list of strings
-
-  :param use_in_production: Whether or not to use unmock in production, based on `ENV` environment variable.
-      Default to False.
-  :type use_in_production boolean
 
   :param whitelist: An optional list (or string) of URLs to whitelist, so that you may access them without unmock
       intercepting the calls. Defaults to ["127.0.0.1", "127.0.0.0", "localhost"]
@@ -31,10 +28,8 @@ def initialize(**kwargs):
 
   core.http.initialize(unmock_options)
 
-  return unmock_options
 
-
-def reset():
+def off():
   """
   Removes Unmock automatic API call capturing, restoring normal behaviour.
   """

--- a/unmock/__init__.py
+++ b/unmock/__init__.py
@@ -57,4 +57,4 @@ class patch:
     return initialize(**self.kwargs)
 
   def __exit__(self, exc_type, exc_val, exc_tb):
-    reset()
+    off()

--- a/unmock/core/__init__.py
+++ b/unmock/core/__init__.py
@@ -1,10 +1,7 @@
-from . import exceptions
+from .utils import *
 from .http import *
 from .options import *
-from .utils import *  # Imported first as it defines the Patchers object
-
-# package-wide variables to be used by different capturers of API calls (whether it is http, flask, django, whatever)
-PATCHERS = Patchers()
+from .request import *
 
 
-__all__ = ["initialize", "reset", "exceptions"]
+__all__ = ["initialize", "reset", "Request"]

--- a/unmock/core/exceptions.py
+++ b/unmock/core/exceptions.py
@@ -1,5 +1,0 @@
-__all__ = ["UnmockException"]
-
-
-class UnmockException(Exception):
-  pass

--- a/unmock/core/http.py
+++ b/unmock/core/http.py
@@ -129,11 +129,12 @@ def initialize(unmock_options):
 
   def unmock_override_get_response(conn, req):
     reply = unmock_options.replyTo(req)
-    m = MockSocket(reply["content"])
+    content = reply.get("content", "")
+    m = MockSocket(content)
     res = http_client.HTTPResponse(m, method=req.method, url=req.url)
 
     res.chunked = False
-    res.length = len(reply["content"])
+    res.length = len(content)
     res.version = (1, 1)
     res.status = reply.get("status", 200)
     res.reason = http_client.responses[res.status]

--- a/unmock/core/options.py
+++ b/unmock/core/options.py
@@ -1,19 +1,11 @@
 import fnmatch
-from six.moves.urllib.parse import urlencode
-from six.moves import http_client
-try:
-  from http import HTTPStatus
-except ImportError:
-  class HTTPStatus:
-    OK = 200
-
 from .utils import parse_url
 
 __all__ = ["UnmockOptions"]
 
 
 class UnmockOptions:
-  def __init__(self, use_in_production=False, whitelist=None):
+  def __init__(self, replyFn, whitelist=None):
     """
     Creates a new UnmockOptions object, customizing the use of Unmock
     :param use_in_production: Whether or not to use unmock in production, based on `ENV` environment variable.
@@ -26,7 +18,7 @@ class UnmockOptions:
 
     """
 
-    self.use_in_production = use_in_production
+    self.replyTo = replyFn
     self.whitelist = whitelist if whitelist is not None else [
         "127.0.0.1", "127.0.0.0", "localhost"]
     if not isinstance(self.whitelist, list):

--- a/unmock/core/options.py
+++ b/unmock/core/options.py
@@ -5,7 +5,7 @@ __all__ = ["UnmockOptions"]
 
 
 class UnmockOptions:
-  def __init__(self, replyFn, whitelist=None):
+  def __init__(self, replyFn=None, whitelist=None):
     """
     Creates a new UnmockOptions object, customizing the use of Unmock
     :param use_in_production: Whether or not to use unmock in production, based on `ENV` environment variable.
@@ -18,7 +18,7 @@ class UnmockOptions:
 
     """
 
-    self.replyTo = replyFn
+    self.replyTo = replyFn if replyFn is not None else (lambda _: dict())
     self.whitelist = whitelist if whitelist is not None else [
         "127.0.0.1", "127.0.0.0", "localhost"]
     if not isinstance(self.whitelist, list):

--- a/unmock/core/request.py
+++ b/unmock/core/request.py
@@ -1,6 +1,7 @@
 import json
 from six.moves.urllib.parse import parse_qs
 from six.moves.http_client import responses
+from .utils import parse_url
 try:
   from unittest import mock
 except ImportError:
@@ -8,10 +9,15 @@ except ImportError:
 
 
 class Request:
-  def __init__(self, host, endpoint, method):
+  def __init__(self, url, method):
+    self.url = url
+    (_, host, endpoint, query, _) = parse_url(url)
     self.host = host
     self.endpoint = endpoint
     self.method = method
+    if query:
+      self.add_query(query)
+
     self.headers = dict()
     self.data = None
     self.qs = dict()

--- a/unmock/core/request.py
+++ b/unmock/core/request.py
@@ -1,0 +1,65 @@
+import json
+from six.moves.urllib.parse import parse_qs
+from six.moves.http_client import responses
+try:
+  from unittest import mock
+except ImportError:
+  import mock
+
+
+class Request:
+  def __init__(self, host, endpoint, method):
+    self.host = host
+    self.endpoint = endpoint
+    self.method = method
+    self.headers = dict()
+    self.data = None
+    self.qs = dict()
+
+  def add_qs(self, key, value):
+    self.qs[key] = value
+
+  def add_query(self, query):
+    parsed = parse_qs(query)
+    for k, v in parsed.items():
+      self.qs[k] = v
+
+  def add_header(self, key, value):
+    self.headers[key] = value
+
+  def add_headers(self, headers):
+    for (k, v) in self.headers:
+      self.headers[k] = v
+
+  def add_body(self, data):
+    self.data = data
+
+
+class Response():
+  def __init__(self, content="", statuscode=200, headers=None):
+    if isinstance(content, str):
+      self.content = content
+    else:
+      self.content = json.dumps(content)
+    self.status = statuscode
+    self.headers = headers or dict()
+    self.n = 0
+
+  def read(self, amt=None):
+    c = self.content
+    if amt:
+      c = self.content[self.n:self.n+amt]
+      self.n += amt
+    return c
+
+  def mock(self):
+    m = mock.MagicMock()
+    # Define the return values for some of HTTPResponse attributes and/or methods
+    m.read.side_effect = lambda amt: self.read(amt)
+    m.status = self.status
+    m.reason = responses[self.status]
+    m.headers = self.headers
+    m.getheaders.return_value = self.headers
+    m.getheader.side_effect = lambda name, default: self.headers.get(
+        name, default)
+    return m

--- a/unmock/core/utils.py
+++ b/unmock/core/utils.py
@@ -1,6 +1,4 @@
 import sys
-import os
-import json
 from six.moves.urllib.parse import urlsplit, SplitResult
 try:
   from unittest import mock
@@ -9,8 +7,8 @@ except ImportError:
 
 from ..__version__ import __version__
 
-__all__ = ["Patchers", "parse_url",
-           "is_python_version_at_least", "makedirs"]
+__all__ = ["PATCHERS", "parse_url",
+           "is_python_version_at_least"]
 
 
 def is_python_version_at_least(version):
@@ -63,7 +61,12 @@ class Patchers:
 
 
 def parse_url(url):
-  """Parses a url using urlsplit, returning a SplitResult. Adds https:// scheme if netloc is empty."""
+  """
+  Parses a url using urlsplit, returning a SplitResult. Adds https:// scheme if netloc is empty.
+  Parse a URL into 5 components:
+    <scheme>://<netloc>/<path>?<query>#<fragment>
+    Return a 5-tuple: (scheme, netloc, path, query, fragment).
+  """
   parsed_url = urlsplit(url)
   if parsed_url.scheme == "" or parsed_url.netloc == "":
     # To make `urlsplit` work we need to provide the protocol; this is arbitrary (and can even be "//")
@@ -71,9 +74,4 @@ def parse_url(url):
   return parsed_url
 
 
-def makedirs(path):
-  """Quiet makedirs (similar to Python3 ok_exists=True flag)"""
-  try:
-    os.makedirs(path)
-  except OSError:
-    pass
+PATCHERS = Patchers()


### PR DESCRIPTION
Updates the httplib mocking and adds a `replyTo` function for `UnmockOptions`.
The `replyTo` function receives a `Request` object (headers, url, endpoint, host, query parameters, etc) and returns a dictionary with any of `content: ...`, `status: N`, `headers: {...}`.